### PR TITLE
Allow gist urls for injection

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -462,14 +462,18 @@ Forces the maximum disk space to be used by the disk cache. Value is given in by
 --inject <value>
 ```
 
-Allows you to inject a javascript or css file. This command can be run multiple times to inject the files.
+Allows you to inject a javascript or css file. This command can be run multiple times to inject the files. This can also be a valid raw Github Gist Url.
 
 _Note:_ The javascript file is loaded _after_ `DOMContentLoaded`, so you can assume the DOM is complete & available.
 
-Example:
+Examples:
 
 ```bash
 nativefier http://google.com --inject ./some-js-injection.js --inject ./some-css-injection.css ~/Desktop
+```
+
+```bash
+nativefier http://google.com --inject ./some-js-injection.js --inject https://gist.githubusercontent.com/vviikk/39cb5208694094b1930190c3c90a3255/raw/209a710bdad81a068f70667732511d91992f48bb/smooth-scrolling.js ~/Desktop
 ```
 
 #### [full-screen]

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "axios": "0.x",
     "commander": "4.x",
+    "download": "^8.0.0",
     "electron-packager": "15.x",
     "gitcloud": "0.x",
     "hasbin": "1.x",

--- a/src/helpers/helpers.test.ts
+++ b/src/helpers/helpers.test.ts
@@ -1,4 +1,4 @@
-import { isArgFormatInvalid } from './helpers';
+import { isArgFormatInvalid, isGistRawUrl } from './helpers';
 
 describe('isArgFormatInvalid', () => {
   test('is false for correct short args', () => {
@@ -32,5 +32,27 @@ describe('isArgFormatInvalid', () => {
 
   test('is false for correct long args with many dashes', () => {
     expect(isArgFormatInvalid('--test-run-with-many-dashes')).toBe(false);
+  });
+
+  test('is true for valid raw gist url', () => {
+    expect(
+      isGistRawUrl(
+        'https://gist.githubusercontent.com/vviikk/39cb5208694094b1930190c3c90a3255/raw/209a710bdad81a068f70667732511d91992f48bb/smooth-scrolling.js',
+      ),
+    ).toBe(true);
+  });
+
+  test('is false for gist url that isnt raw or not gist URL', () => {
+    expect(
+      isGistRawUrl(
+        'https://gist.github.com/vviikk/39cb5208694094b1930190c3c90a3255',
+      ),
+    ).toBe(false);
+
+    expect(
+      isGistRawUrl(
+        'https://someurl.com/gist/github/39cb5208694094b1930190c3c90a3255',
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Would love to have this function whereby valid gist urls (i,e, stuff like userscripts & themes on github) to be injected without download.