### PR TITLE
Docker: slim down image size, by removing temp/cache files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+# git
+.git*
+
 # OSX
 .DS_Store
 
@@ -7,11 +10,12 @@
 lib/*
 app/lib/*
 built-tests
-
-# commit a placeholder to keep the app/lib directory
-!app/lib/.placeholder
-
 dist
+app/dist
+
+# Docs
+docs
+*.md
 
 # Logs
 logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,9 @@ RUN npm install
 WORKDIR /nativefier
 
 # Install (note that we had to manually install in `app` before, as `prepare` won't run as root)
-# Also, running tests, to ensure we don't Docker build & publish broken stuff
-RUN npm install && npm run build && npm test && npm link
+# Also, running tests, to ensure we don't Docker build & publish broken stuff, and cleanup test files
+RUN npm install && npm run build && npm test && npm link && rm -rf /tmp/nativefier*
 
-# Cleanup test artifacts
-RUN rm -rf /tmp/nativefier*
 
 # Use 1000 as default user not root
 USER 1000
@@ -33,13 +31,14 @@ USER 1000
 # Run a {lin,mac,win} build
 # 1. to check installation was sucessful
 # 2. to cache electron distributables and avoid downloads at runtime
+# Also delete generated apps so they don't get added to the Docker layer
 RUN nativefier https://github.com/nativefier/nativefier /tmp/nativefier \
     && nativefier -p osx https://github.com/nativefier/nativefier /tmp/nativefier \
-    && nativefier -p windows https://github.com/nativefier/nativefier /tmp/nativefier
+    && nativefier -p windows https://github.com/nativefier/nativefier /tmp/nativefier \
+    && rm -rf /tmp/nativefier
 
 
 RUN echo Generated Electron cache size: $(du -sh ~/.cache/electron) \
-    && rm -rf /tmp/nativefier \
     && echo Final image size: $(du -sh / 2>/dev/null)
 
 ENTRYPOINT ["nativefier"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,11 @@ WORKDIR /nativefier
 
 # Install (note that we had to manually install in `app` before, as `prepare` won't run as root)
 # Also, running tests, to ensure we don't Docker build & publish broken stuff, and cleanup test files
-RUN npm install && npm run build && npm test && npm link && rm -rf /tmp/nativefier*
+RUN npm install \
+  && npm run build \
+  && npm test \
+  && npm link \
+  && rm -rf /tmp/nativefier*
 
 
 # Use 1000 as default user not root


### PR DESCRIPTION
Per the [note](https://github.com/nativefier/nativefier/pull/1122#discussion_r588922780) by @SuperSandro2000 in #1122 Docker will still cache files in intermediate layers if you delete them, so they'll still be part of the image.

Only solution seems to be to delete them as you create them so they don't cache:
Per https://stackoverflow.com/questions/53998310/docker-remove-file-from-intermediate-layer