### PR TITLE
Automatically-internal login URLs: add GitHub 2FA pages

### DIFF
--- a/app/src/helpers/helpers.test.ts
+++ b/app/src/helpers/helpers.test.ts
@@ -92,6 +92,21 @@ test.each(testLoginPages)(
   },
 );
 
+// Ensure that we don't over-match service pages
+const testNonLoginPages = [
+  'https://www.amazon.com/Node-Cookbook-techniques-server-side-development-ebook',
+  'https://github.com/nativefier/nativefier',
+  'https://github.com/org/nativefier',
+  'https://twitter.com/marcoroth_/status/1325938620906287104',
+];
+
+test.each(testNonLoginPages)(
+  '%s page should not be internal',
+  (url: string) => {
+    expect(linkIsInternal(internalUrl, url, undefined)).toEqual(true);
+  },
+);
+
 const smallCounterTitle = 'Inbox (11) - nobody@example.com - Gmail';
 const largeCounterTitle = 'Inbox (8,756) - nobody@example.com - Gmail';
 const noCounterTitle = 'Inbox - nobody@example.com - Gmail';

--- a/app/src/helpers/helpers.test.ts
+++ b/app/src/helpers/helpers.test.ts
@@ -103,7 +103,7 @@ const testNonLoginPages = [
 test.each(testNonLoginPages)(
   '%s page should not be internal',
   (url: string) => {
-    expect(linkIsInternal(internalUrl, url, undefined)).toEqual(true);
+    expect(linkIsInternal(internalUrl, url, undefined)).toEqual(false);
   },
 );
 

--- a/app/src/helpers/helpers.test.ts
+++ b/app/src/helpers/helpers.test.ts
@@ -64,6 +64,9 @@ const testLoginPages = [
   'https://github.co.uk/login',
   'https://github.com/login',
   'https://github.de/login',
+  // GitHub 2FA flow with FIDO token
+  'https://github.com/session',
+  'https://github.com/sessions/two-factor/webauth',
   'https://accounts.google.co.uk',
   'https://accounts.google.com',
   'https://accounts.google.de',

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -22,7 +22,7 @@ function isInternalLoginPage(url: string): boolean {
   const internalLoginPagesArray = [
     'amazon\\.[a-zA-Z\\.]*/[a-zA-Z\\/]*signin', // Amazon
     `facebook\\.[a-zA-Z\\.]*\\/login`, // Facebook
-    'github\\.[a-zA-Z\\.]*\\/login', // GitHub
+    'github\\.[a-zA-Z\\.]*\\/(?:login|session)', // GitHub
     'accounts\\.google\\.[a-zA-Z\\.]*', // Google
     'linkedin\\.[a-zA-Z\\.]*/uas/login', // LinkedIn
     'login\\.live\\.[a-zA-Z\\.]*', // Microsoft


### PR DESCRIPTION
I have 2FA (FIDO/Yubikey) set up for GitHub, and the session login was redirecting to my browser. Looking at the redirect path, it appears that github.com/session is involved, so adding that to internal login details.

With this patched, I'm able to login in to https://octobox.io/ in nativefier.

