### PR TITLE
Add Apple ID to automatically-internal login pages

### DIFF
--- a/app/src/helpers/helpers.test.ts
+++ b/app/src/helpers/helpers.test.ts
@@ -83,6 +83,7 @@ const testLoginPages = [
   'https://twitter.co.uk/oauth/authenticate',
   'https://twitter.com/oauth/authenticate',
   'https://twitter.de/oauth/authenticate',
+  'https://appleid.apple.com/auth/authorize',
 ];
 
 test.each(testLoginPages)(
@@ -98,6 +99,7 @@ const testNonLoginPages = [
   'https://github.com/nativefier/nativefier',
   'https://github.com/org/nativefier',
   'https://twitter.com/marcoroth_/status/1325938620906287104',
+  'https://appleid.apple.com/account',
 ];
 
 test.each(testNonLoginPages)(

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -19,6 +19,7 @@ export function isWindows(): boolean {
 }
 
 function isInternalLoginPage(url: string): boolean {
+  // Making changes? Remember to update the tests in helpers.test.ts
   const internalLoginPagesArray = [
     'amazon\\.[a-zA-Z\\.]*/[a-zA-Z\\/]*signin', // Amazon
     `facebook\\.[a-zA-Z\\.]*\\/login`, // Facebook
@@ -28,6 +29,7 @@ function isInternalLoginPage(url: string): boolean {
     'login\\.live\\.[a-zA-Z\\.]*', // Microsoft
     'okta\\.[a-zA-Z\\.]*', // Okta
     'twitter\\.[a-zA-Z\\.]*/oauth/authenticate', // Twitter
+    'appleid\\.apple\\.com/auth/authorize', // Apple
   ];
   const regex = RegExp(internalLoginPagesArray.join('|'));
   return regex.test(url);


### PR DESCRIPTION
Used by [Notion](https://www.notion.so/login), for example. TLDs other than `.com` don't appear to exist.