### PR TITLE
Support defining a custom bookmarks menu (fix #1065)

### DIFF
--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -230,6 +230,9 @@ export function createMainWindow(
   const getCurrentUrl = (): void =>
     withFocusedWindow((focusedWindow) => focusedWindow.webContents.getURL());
 
+  const gotoUrl = (url: string): void =>
+    withFocusedWindow((focusedWindow) => void focusedWindow.loadURL(url));
+
   const onBlockedExternalUrl = (url: string) => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     dialog.showMessageBox(mainWindow, {
@@ -342,6 +345,7 @@ export function createMainWindow(
     goBack: onGoBack,
     goForward: onGoForward,
     getCurrentUrl,
+    gotoUrl,
     clearAppData,
     disableDevTools: options.disableDevTools,
   };

--- a/app/src/components/menu.ts
+++ b/app/src/components/menu.ts
@@ -315,6 +315,16 @@ export function createMenu({
         label: bookmarksMenuConfig.menuLabel,
         submenu: bookmarksMenuConfig.bookmarks.map((bookmark) => {
           if (bookmark.type === 'link') {
+            if (!('title' in bookmark && 'url' in bookmark)) {
+              throw Error(
+                'All links in the bookmarks menu must have a title and url.',
+              );
+            }
+            try {
+              new URL(bookmark.url);
+            } catch (_) {
+              throw Error('Bookmark URL "' + bookmark.url + '"is invalid.');
+            }
             let accelerator = null;
             if ('shortcut' in bookmark) {
               accelerator = bookmark.shortcut;
@@ -330,6 +340,10 @@ export function createMenu({
             return {
               type: 'separator',
             };
+          } else {
+            throw Error(
+              'A bookmarks menu entry has an invalid type; type must be one of "link", "separator".',
+            );
           }
         }),
       };

--- a/app/src/components/menu.ts
+++ b/app/src/components/menu.ts
@@ -298,20 +298,20 @@ export function createMenu({
       );
       const bookmarksMenu: MenuItemConstructorOptions = {
         label: bookmarksConfig['menuLabel'],
-        submenu: bookmarksConfig['bookmarks'].map((el) => {
-          if (el['type'] === 'link') {
+        submenu: bookmarksConfig['bookmarks'].map((bookmark) => {
+          if (bookmark['type'] === 'link') {
             let accelerator = null;
-            if ('shortcut' in el) {
-              accelerator = el['shortcut'];
+            if ('shortcut' in bookmark) {
+              accelerator = bookmark['shortcut'];
             }
             return {
-              label: el['title'],
+              label: bookmark['title'],
               click: () => {
-                gotoUrl(el['url']);
+                gotoUrl(bookmark['url']);
               },
               accelerator: accelerator,
             };
-          } else if (el['type'] === 'separator') {
+          } else if (bookmark['type'] === 'separator') {
             return {
               type: 'separator',
             };

--- a/app/src/components/menu.ts
+++ b/app/src/components/menu.ts
@@ -347,6 +347,7 @@ export function createMenu({
           }
         }),
       };
+      // Insert custom bookmarks menu between menus "View" and "Window"
       menuTemplate.splice(menuTemplate.length - 2, 0, bookmarksMenu);
     }
   } catch (err) {

--- a/app/src/components/menu.ts
+++ b/app/src/components/menu.ts
@@ -3,6 +3,21 @@ import path from 'path';
 
 import { Menu, clipboard, shell, MenuItemConstructorOptions } from 'electron';
 
+type BookmarksLink = {
+  type: 'link';
+  title: string;
+  url: string;
+  shortcut?: string;
+};
+type BookmarksSeparator = {
+  type: 'separator';
+};
+type BookmarkConfig = BookmarksLink | BookmarksSeparator;
+type BookmarksMenuConfig = {
+  menuLabel: string;
+  bookmarks: BookmarkConfig[];
+};
+
 export function createMenu({
   nativefierVersion,
   appQuit,
@@ -293,25 +308,25 @@ export function createMenu({
   try {
     const bookmarkConfigPath = path.join(__dirname, '..', 'bookmarks.json');
     if (fs.existsSync(bookmarkConfigPath)) {
-      const bookmarksConfig = JSON.parse(
+      const bookmarksMenuConfig: BookmarksMenuConfig = JSON.parse(
         fs.readFileSync(bookmarkConfigPath, 'utf-8'),
       );
       const bookmarksMenu: MenuItemConstructorOptions = {
-        label: bookmarksConfig['menuLabel'],
-        submenu: bookmarksConfig['bookmarks'].map((bookmark) => {
-          if (bookmark['type'] === 'link') {
+        label: bookmarksMenuConfig.menuLabel,
+        submenu: bookmarksMenuConfig.bookmarks.map((bookmark) => {
+          if (bookmark.type === 'link') {
             let accelerator = null;
             if ('shortcut' in bookmark) {
-              accelerator = bookmark['shortcut'];
+              accelerator = bookmark.shortcut;
             }
             return {
-              label: bookmark['title'],
+              label: bookmark.title,
               click: () => {
-                gotoUrl(bookmark['url']);
+                gotoUrl(bookmark.url);
               },
               accelerator: accelerator,
             };
-          } else if (bookmark['type'] === 'separator') {
+          } else if (bookmark.type === 'separator') {
             return {
               type: 'separator',
             };

--- a/app/src/components/menu.ts
+++ b/app/src/components/menu.ts
@@ -1,6 +1,7 @@
-import { Menu, clipboard, shell, MenuItemConstructorOptions } from 'electron';
 import * as fs from 'fs';
 import path from 'path';
+
+import { Menu, clipboard, shell, MenuItemConstructorOptions } from 'electron';
 
 export function createMenu({
   nativefierVersion,

--- a/app/src/components/menu.ts
+++ b/app/src/components/menu.ts
@@ -289,34 +289,41 @@ export function createMenu({
     menuTemplate = [editMenu, viewMenu, windowMenu, helpMenu];
   }
 
-  const bookmarkConfigPath = path.join(__dirname, '..', 'bookmarks.json');
-  if (fs.existsSync(bookmarkConfigPath)) {
-    const bookmarksConfig = JSON.parse(
-      fs.readFileSync(bookmarkConfigPath, 'utf-8'),
-    );
-    const bookmarksMenu: MenuItemConstructorOptions = {
-      label: bookmarksConfig['menuLabel'],
-      submenu: bookmarksConfig['bookmarks'].map((el) => {
-        if (el['type'] === 'link') {
-          let accelerator = null;
-          if ('shortcut' in el) {
-            accelerator = el['shortcut'];
+  try {
+    const bookmarkConfigPath = path.join(__dirname, '..', 'bookmarks.json');
+    if (fs.existsSync(bookmarkConfigPath)) {
+      const bookmarksConfig = JSON.parse(
+        fs.readFileSync(bookmarkConfigPath, 'utf-8'),
+      );
+      const bookmarksMenu: MenuItemConstructorOptions = {
+        label: bookmarksConfig['menuLabel'],
+        submenu: bookmarksConfig['bookmarks'].map((el) => {
+          if (el['type'] === 'link') {
+            let accelerator = null;
+            if ('shortcut' in el) {
+              accelerator = el['shortcut'];
+            }
+            return {
+              label: el['title'],
+              click: () => {
+                gotoUrl(el['url']);
+              },
+              accelerator: accelerator,
+            };
+          } else if (el['type'] === 'separator') {
+            return {
+              type: 'separator',
+            };
           }
-          return {
-            label: el['title'],
-            click: () => {
-              gotoUrl(el['url']);
-            },
-            accelerator: accelerator,
-          };
-        } else if (el['type'] === 'separator') {
-          return {
-            type: 'separator',
-          };
-        }
-      }),
-    };
-    menuTemplate.splice(menuTemplate.length - 2, 0, bookmarksMenu);
+        }),
+      };
+      menuTemplate.splice(menuTemplate.length - 2, 0, bookmarksMenu);
+    }
+  } catch (err) {
+    console.warn(
+      'Failed to load & parse bookmarks configuration JSON file.',
+      err,
+    );
   }
 
   const menu = Menu.buildFromTemplate(menuTemplate);

--- a/docs/api.md
+++ b/docs/api.md
@@ -807,6 +807,8 @@ This menu is a simple list; folders are not supported.
 
 Your `menuLabel` can be bound to a `Alt + letter` shortcut using the letter `&` before the `letter` you want. Be careful to not conflict with the letter of other menus!
 
+Keyboard shortcuts can use the modifier keys `Cmd`, `Ctrl`, `CmdOrCtrl`, `Alt`, `Option`, `AltGr`, `Shift`, and `Super`. See [the Electron documentation](https://www.electronjs.org/docs/api/accelerator) for more information.
+
 Example of such a JSON file:
 
 ```json
@@ -817,13 +819,13 @@ Example of such a JSON file:
             "title": "lofi.cafe",
             "url": "https://lofi.cafe/",
             "type": "link",
-            "shortcut": "Cmd+1"
+            "shortcut": "CmdOrCtrl+1"
         },
         {
             "title": "beats to relax/study to",
             "url": "https://www.youtube.com/watch?v=5qap5aO4i9A",
             "type": "link",
-            "shortcut": "Cmd+2"
+            "shortcut": "CmdOrCtrl+2"
         },
         {
             "type": "separator"

--- a/docs/api.md
+++ b/docs/api.md
@@ -801,7 +801,11 @@ See https://electronjs.org/docs/api/browser-window#setting-backgroundcolor
 --bookmarks-menu <string>
 ```
 
-Path to a JSON file containing configuration for a predefined bookmarks menu. In addition to containing a list of bookmarks, this file customizes the name of the menu and (optionally) allows assigning keyboard shortcuts to bookmarks.
+Path to a JSON file defining a bookmarks menu. In addition to containing a list of bookmarks, this file customizes the name of the menu and (optionally) allows assigning keyboard shortcuts to bookmarks.
+
+This menu is a simple list; folders are not supported.
+
+Your `menuLabel` can be bound to a `Alt + letter` shortcut using the letter `&` before the `letter` you want. Be careful to not conflict with the letter of other menus!
 
 Example of such a JSON file:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -813,7 +813,7 @@ Example of such a JSON file:
 
 ```json
 {
-    "menuLabel": "Music",
+    "menuLabel": "&Music",
     "bookmarks": [
         {
             "title": "lofi.cafe",

--- a/docs/api.md
+++ b/docs/api.md
@@ -68,6 +68,7 @@
   - [[browserwindow-options]](#browserwindow-options)
   - [[darwin-dark-mode-support]](#darwin-dark-mode-support)
   - [[background-color]](#background-color)
+  - [[bookmarks-menu]](#bookmarks-menu)
   - [Deprecated](#deprecated)
     - [[flash] and [flash-path]](#flash) (DEPRECATED)
 - [Programmatic API](#programmatic-api)
@@ -793,6 +794,45 @@ Enables Dark Mode support on macOS 10.14+.
 ```
 
 See https://electronjs.org/docs/api/browser-window#setting-backgroundcolor
+
+#### [bookmarks-menu]
+
+```
+--bookmarks-menu <string>
+```
+
+Path to a JSON file containing configuration for a predefined bookmarks menu. In addition to containing a list of bookmarks, this file customizes the name of the menu and (optionally) allows assigning keyboard shortcuts to bookmarks.
+
+Example of such a JSON file:
+
+```json
+{
+    "menuLabel": "Music",
+    "bookmarks": [
+        {
+            "title": "lofi.cafe",
+            "url": "https://lofi.cafe/",
+            "type": "link",
+            "shortcut": "Cmd+1"
+        },
+        {
+            "title": "beats to relax/study to",
+            "url": "https://www.youtube.com/watch?v=5qap5aO4i9A",
+            "type": "link",
+            "shortcut": "Cmd+2"
+        },
+        {
+            "type": "separator"
+        },
+        {
+            "title": "RÜFÜS DU SOL Live from Joshua Tree",
+            "type": "link",
+            "url": "https://www.youtube.com/watch?v=Zy4KtD98S2c"
+        }
+    ]
+}
+
+```
 
 ### Deprecated
 

--- a/src/build/prepareElectronApp.ts
+++ b/src/build/prepareElectronApp.ts
@@ -156,6 +156,15 @@ export async function prepareElectronApp(
     JSON.stringify(pickElectronAppArgs(options)),
   );
 
+  if (options.nativefier.bookmarksMenu) {
+    const bookmarksJsonPath = path.join(dest, '/bookmarks.json');
+    try {
+      await copyFileOrDir(options.nativefier.bookmarksMenu, bookmarksJsonPath);
+    } catch (err) {
+      log.error('Error copying bookmarks menu config file.', err);
+    }
+  }
+
   try {
     await maybeCopyScripts(options.nativefier.inject, dest);
   } catch (err) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -274,6 +274,10 @@ if (require.main === module) {
     .option(
       '--darwin-dark-mode-support',
       '(macOS only) enable Dark Mode support on macOS 10.14+',
+    )
+    .option(
+      '--bookmarks-menu <value>',
+      'Path to JSON configuration file for the bookmarks menu.',
     );
 
   try {

--- a/src/options/model.ts
+++ b/src/options/model.ts
@@ -13,6 +13,7 @@ export interface AppOptions {
     backgroundColor: string;
     basicAuthPassword: string;
     basicAuthUsername: string;
+    bookmarksMenu: string;
     bounce: boolean;
     browserwindowOptions: any;
     clearCache: boolean;

--- a/src/options/optionsMain.ts
+++ b/src/options/optionsMain.ts
@@ -52,6 +52,7 @@ export async function getOptions(rawOptions: any): Promise<AppOptions> {
       backgroundColor: rawOptions.backgroundColor || null,
       basicAuthPassword: rawOptions.basicAuthPassword || null,
       basicAuthUsername: rawOptions.basicAuthUsername || null,
+      bookmarksMenu: rawOptions.bookmarksMenu || null,
       bounce: rawOptions.bounce || false,
       browserwindowOptions: rawOptions.browserwindowOptions,
       clearCache: rawOptions.clearCache || false,


### PR DESCRIPTION
This PR adds an optional, customizable menu of predefined bookmarks. In addition to containing a list of bookmarks, this file customizes the name of the menu and (optionally) allows assigning keyboard shortcuts to bookmarks. It adds a new command-line flag, `--bookmarks-menu <string>`, which can be set as the path to a JSON file containing configuration for the bookmarks menu.

Example of such a JSON file:

```json
{
    "menuLabel": "Music",
    "bookmarks": [
        {
            "title": "lofi.cafe",
            "url": "https://lofi.cafe/",
            "type": "link",
            "shortcut": "Cmd+1"
        },
        {
            "title": "beats to relax/study to",
            "url": "https://www.youtube.com/watch?v=5qap5aO4i9A",
            "type": "link",
            "shortcut": "Cmd+2"
        },
        {
            "type": "separator"
        },
        {
            "title": "RÜFÜS DU SOL Live from Joshua Tree",
            "type": "link",
            "url": "https://www.youtube.com/watch?v=Zy4KtD98S2c"
        }
    ]
}
```

## Checks
- [x] `npm run ci` passes

## Notes

Compared to the fork linked in #1065, this PR:
- adds no dependencies
- doesn't currently support submenus (this should be easy enough to add, but I didn't need it)

## Screenshot

<img width="853" alt="screenshot" src="https://user-images.githubusercontent.com/102904/115882015-5493a800-a41a-11eb-85ef-a190f3dbfe76.png">
