### PR TITLE
macOS: Fix crash when using --tray (fix #527), and invisible icon (fix #942, fix #668)

### DIFF
--- a/app/src/components/trayIcon.ts
+++ b/app/src/components/trayIcon.ts
@@ -1,6 +1,6 @@
 import { app, Tray, Menu, ipcMain, nativeImage, BrowserWindow } from 'electron';
 
-import { getAppIcon, getCounterValue } from '../helpers/helpers';
+import { getAppIcon, getCounterValue, isOSX } from '../helpers/helpers';
 
 export function createTrayIcon(
   nativefierOptions,
@@ -11,7 +11,16 @@ export function createTrayIcon(
   if (options.tray) {
     const iconPath = getAppIcon();
     const nimage = nativeImage.createFromPath(iconPath);
-    const appIcon = new Tray(nimage);
+    const appIcon = new Tray(nativeImage.createEmpty());
+
+    if (isOSX()) {
+      //sets the icon to the height of the tray.
+      appIcon.setImage(
+        nimage.resize({ height: appIcon.getBounds().height - 2 }),
+      );
+    } else {
+      appIcon.setImage(nimage);
+    }
 
     const onClick = () => {
       if (mainWindow.isVisible()) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -620,6 +620,8 @@ Application will stay as an icon in the system tray. Prevents application from b
 
 When the optional argument `start-in-tray` is provided, i.e. the application is started using `--tray start-in-tray`, the main window will not be shown on first start.
 
+Note: When creating a macOS application with the --tray option on a non macOS host machine, the tray icon will not be visible in the menu bar.
+
 #### [basic-auth-username]
 
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -620,7 +620,7 @@ Application will stay as an icon in the system tray. Prevents application from b
 
 When the optional argument `start-in-tray` is provided, i.e. the application is started using `--tray start-in-tray`, the main window will not be shown on first start.
 
-Note: When creating a macOS application with the --tray option on a non macOS host machine, the tray icon will not be visible in the menu bar.
+Limitation: when creating a macOS app using option `--tray`, from a non-macOS build machine, the tray icon (in the menu bar) will be invisible.
 
 #### [basic-auth-username]
 

--- a/icon-scripts/convertToTrayIcon
+++ b/icon-scripts/convertToTrayIcon
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# USAGE
+
+# ./convertToTrayIcon <input png or icns> <outfilename>.png
+# Example
+# ./convertToTrayIcon ~/sample.icns ~/converted.png
+
+set -e
+
+SOURCE=$1
+DEST=$2
+
+if [ -z "${SOURCE}" ]; then
+	echo "No source image specified"
+	exit 1
+fi
+
+if [ -z "${DEST}" ]; then
+	echo "No destination specified"
+	exit 1
+fi
+
+NAME=$(basename "${SOURCE}")
+EXT="${NAME##*.}"
+
+if [ "${EXT}" == "png" ]; then
+    cp "${SOURCE}" "${DEST}"
+    exit 0
+fi
+
+sips --setProperty format png --resampleHeightWidth "256" "256" "${SOURCE}" --out "${DEST}"

--- a/src/build/buildIcon.ts
+++ b/src/build/buildIcon.ts
@@ -7,6 +7,7 @@ import {
   convertToPng,
   convertToIco,
   convertToIcns,
+  convertToTrayIcon,
 } from '../helpers/iconShellHelpers';
 import { AppOptions } from '../options/model';
 
@@ -72,7 +73,6 @@ export function convertIconIfNecessary(options: AppOptions): void {
     log.debug(
       'Building for macOS and icon is already a .icns, no conversion needed',
     );
-    return;
   }
 
   if (!isOSX()) {
@@ -83,12 +83,16 @@ export function convertIconIfNecessary(options: AppOptions): void {
   }
 
   try {
-    const iconPath = convertToIcns(options.packager.icon);
-    options.packager.icon = iconPath;
-    return;
+    if (!iconIsIcns(options.packager.icon)) {
+      const iconPath = convertToIcns(options.packager.icon);
+      options.packager.icon = iconPath;
+    }
+    if (options.nativefier.tray) {
+      convertToTrayIcon(options.packager.icon);
+    }
   } catch (error) {
     log.warn('Failed to convert icon to .icns, skipping.', error);
     options.packager.icon = undefined;
-    return;
   }
+  return;
 }

--- a/src/build/buildIcon.ts
+++ b/src/build/buildIcon.ts
@@ -94,5 +94,4 @@ export function convertIconIfNecessary(options: AppOptions): void {
     log.warn('Failed to convert icon to .icns, skipping.', error);
     options.packager.icon = undefined;
   }
-  return;
 }

--- a/src/build/buildNativefierApp.ts
+++ b/src/build/buildNativefierApp.ts
@@ -65,7 +65,18 @@ async function copyIconsIfNecessary(
     options.packager.platform === 'darwin' ||
     options.packager.platform === 'mas'
   ) {
-    log.debug('No copying necessary on macOS; aborting');
+    if (options.nativefier.tray) {
+      //tray icon needs to be .png
+      log.debug('Copying icon for tray application');
+      const trayIconFileName = `icon.png`;
+      const destIconPath = path.join(appPath, trayIconFileName);
+      await copyFileOrDir(
+        `${path.dirname(options.packager.icon)}/${trayIconFileName}`,
+        destIconPath,
+      );
+    } else {
+      log.debug('No copying necessary on macOS; aborting');
+    }
     return;
   }
 

--- a/src/build/buildNativefierApp.ts
+++ b/src/build/buildNativefierApp.ts
@@ -68,8 +68,8 @@ async function copyIconsIfNecessary(
     if (options.nativefier.tray) {
       //tray icon needs to be .png
       log.debug('Copying icon for tray application');
-      const trayIconFileName = `icon.png`;
-      const destIconPath = path.join(appPath, trayIconFileName);
+      const trayIconFileName = `tray-icon.png`;
+      const destIconPath = path.join(appPath, 'icon.png');
       await copyFileOrDir(
         `${path.dirname(options.packager.icon)}/${trayIconFileName}`,
         destIconPath,

--- a/src/helpers/iconShellHelpers.ts
+++ b/src/helpers/iconShellHelpers.ts
@@ -95,6 +95,6 @@ export function convertToTrayIcon(icoSrc: string): string {
   return iconShellHelper(
     SCRIPT_PATHS.convertToTrayIcon,
     icoSrc,
-    `${path.dirname(icoSrc)}/icon.png`,
+    `${path.dirname(icoSrc)}/tray-icon.png`,
   );
 }

--- a/src/helpers/iconShellHelpers.ts
+++ b/src/helpers/iconShellHelpers.ts
@@ -9,6 +9,11 @@ const SCRIPT_PATHS = {
   convertToPng: path.join(__dirname, '../..', 'icon-scripts/convertToPng'),
   convertToIco: path.join(__dirname, '../..', 'icon-scripts/convertToIco'),
   convertToIcns: path.join(__dirname, '../..', 'icon-scripts/convertToIcns'),
+  convertToTrayIcon: path.join(
+    __dirname,
+    '../..',
+    'icon-scripts/convertToTrayIcon',
+  ),
 };
 
 /**
@@ -22,8 +27,8 @@ function iconShellHelper(
   if (isWindows()) {
     throw new Error(
       'Icon conversion only supported on macOS or Linux. ' +
-        'If building for Windows, download/create a .ico and pass it with --icon favicon.ico . ' +
-        'If building for macOS/Linux, do it from macOS/Linux',
+      'If building for Windows, download/create a .ico and pass it with --icon favicon.ico . ' +
+      'If building for macOS/Linux, do it from macOS/Linux',
     );
   }
 
@@ -79,5 +84,17 @@ export function convertToIcns(icoSrc: string): string {
     SCRIPT_PATHS.convertToIcns,
     icoSrc,
     `${getTempDir('iconconv')}/icon.icns`,
+  );
+}
+
+export function convertToTrayIcon(icoSrc: string): string {
+  if (!isOSX()) {
+    throw new Error('macOS is required to convert from a .icns icon');
+  }
+
+  return iconShellHelper(
+    SCRIPT_PATHS.convertToTrayIcon,
+    icoSrc,
+    `${path.dirname(icoSrc)}/icon.png`,
   );
 }

--- a/src/helpers/iconShellHelpers.ts
+++ b/src/helpers/iconShellHelpers.ts
@@ -27,8 +27,8 @@ function iconShellHelper(
   if (isWindows()) {
     throw new Error(
       'Icon conversion only supported on macOS or Linux. ' +
-      'If building for Windows, download/create a .ico and pass it with --icon favicon.ico . ' +
-      'If building for macOS/Linux, do it from macOS/Linux',
+        'If building for Windows, download/create a .ico and pass it with --icon favicon.ico . ' +
+        'If building for macOS/Linux, do it from macOS/Linux',
     );
   }
 


### PR DESCRIPTION
This PR is meant to fix a startup crash on macOS when using the --tray cli option, it's mentioned in #527.

![image](https://user-images.githubusercontent.com/22625791/115987741-99544600-a5b6-11eb-866a-dadb5640eecb.png)
 
It will also accomplish to correctly display the tray icon on macOS, which would close #942 and #668.  

![image](https://user-images.githubusercontent.com/22625791/115988276-24364000-a5b9-11eb-80c3-561a8a646754.png)

Example:

`
nativefier "web.whatsapp.com" --tray
`
