### PR TITLE
README: add troubleshooting section for common issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,6 +16,7 @@ Incomprehensible / incomplete bug reports will be closed.
 **Homework**
 
 - [ ] I looked at `nativefier --help` and https://github.com/nativefier/nativefier/blob/master/docs/api.md
+- [ ] I checked the [Troubleshooting section of the README](https://github.com/nativefier/nativefier/blob/master/README.md#troubleshooting).
 - [ ] I searched existing issues, open & closed. Yes, my bug is new.
 - [ ] I'm using the latest version available at https://github.com/nativefier/nativefier/releases
 

--- a/README.md
+++ b/README.md
@@ -88,3 +88,49 @@ Help welcome on [bugs](https://github.com/nativefier/nativefier/issues?q=is%3Aop
 ## License
 
 [MIT](LICENSE.md)
+
+## Troubleshooting
+
+Before submitting question or bug report, please ensure you have read through these common issues and see if you can resolve the problem on your own. If you still encounter issues after trying these steps, or you don't see something similar to your issue listed, please submit a [bug report](https://github.com/nativefier/nativefier/issues/new?assignees=&labels=bug&template=bug_report.md).
+
+### I am trying to use Nativefier to build an app for a site that tells me I have an old/unsupported browser.
+
+This issue comes up for sites that do not wish to support an app made with Nativefier or similar technologies (such as [Google](https://github.com/nativefier/nativefier/issues/831) and [WhatsApp](https://github.com/nativefier/nativefier/issues/1112))
+
+#### Troubleshooting Steps
+
+1. First try setting the [`--user-agent`](https://github.com/nativefier/nativefier/blob/master/docs/api.md#user-agent) to something different. Try using the value you would get at [https://www.whatismybrowser.com/detect/what-is-my-user-agent] and use your current browser's user agent.
+2. If this doesn't work, the site (such as WhatsApp) may be using a service worker to analyze the app and detect. You can disable the service worker cache by doing the following, which is a known fix for WhatsApp:
+    1.  Create a javascript file containing the following snippet:
+        ```javascript
+        if ('serviceWorker' in navigator) {
+            caches.keys().then(function (cacheNames) {
+                cacheNames.forEach(function (cacheName) {
+                    caches.delete(cacheName);
+                });
+            });
+        }
+        ```
+    2. Inject the javascript file into your app when generating it with the [`--inject`](https://github.com/nativefier/nativefier/blob/master/docs/api.md#inject) argument.
+
+### I am trying to use Nativefier to build an app for a site with video, but the video won't play.
+
+This issue comes up for certain sites like [HBO Max](https://github.com/nativefier/nativefier/issues/1153) and [Udemy](https://github.com/nativefier/nativefier/issues/1147).
+
+#### Troubleshooting Steps
+
+1. First try using the [`--widevine`](https://github.com/nativefier/nativefier/blob/master/docs/api.md#widevine) argument when building the app. This uses the [Castlabs version of Electron](https://github.com/castlabs/electron-releases) which allows the playback of DRM enabled video.
+2. If this doesn't work, the site may require your app to be signed for `--widevine` to work. See the [Castlabs documentation](https://github.com/castlabs/electron-releases/wiki/EVS) on using their application signing service to sign the application.
+
+### I am trying different options to Nativefier to experiment with, but noticing that sometimes things cache between rebuilds of my app.
+
+This issue can occur because the cache of the app and the app itself are kept separate by default. You can try clearing out the cache.
+
+#### Troubleshooting Steps
+
+1. Delete your app's cache, which can be found under the folder `<your_app_name_lower_case>-nativefier-<random_id>` in your OS's app data directory
+    - `<your_app_name_lower_case>` represents the lowercase version of your app's name. E.g., GitHub would be `github`.
+    - `<random_id>` represents a randomly generated id for your app. Open the containing folder to see what it may be.
+2. For Linux, the app data directory is `$XDG_CONFIG_HOME` or `~/.config`
+3. For MacOS, the app data directory is `~/Library/Application\ Support/`
+4. For Windows, the app data directory is `%APPDATA%`

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Help welcome on [bugs](https://github.com/nativefier/nativefier/issues?q=is%3Aop
 
 ## Troubleshooting
 
-Before submitting question or bug report, please ensure you have read through these common issues and see if you can resolve the problem on your own. If you still encounter issues after trying these steps, or you don't see something similar to your issue listed, please submit a [bug report](https://github.com/nativefier/nativefier/issues/new?assignees=&labels=bug&template=bug_report.md).
+Before submitting a question or bug report, please ensure you have read through these common issues and see if you can resolve the problem on your own. If you still encounter issues after trying these steps, or you don't see something similar to your issue listed, please submit a [bug report](https://github.com/nativefier/nativefier/issues/new?assignees=&labels=bug&template=bug_report.md).
 
 ### I am trying to use Nativefier to build an app for a site that tells me I have an old/unsupported browser.
 


### PR DESCRIPTION
Per #1112, I'm adding some common troubleshooting steps to the README. As well, this adds a checkbox requesting users to check this section before submitting a ticket, which will hopefully lead to more self-help.