### PR TITLE
linkIsInternal: consider shop.foo.com and blog.foo.com as internal (still without extra dep or SLD list)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ venv
 # IntelliJ project files
 .idea
 *.iml
+.run
 out
 gen
 

--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,8 @@
     "electron-dl": "^3.2.0",
     "electron-squirrel-startup": "^1.0.0",
     "electron-window-state": "^5.0.3",
-    "source-map-support": "^0.5.19"
+    "source-map-support": "^0.5.19",
+    "tldts": "latest"
   },
   "devDependencies": {
     "electron": "^12.0.1"

--- a/app/package.json
+++ b/app/package.json
@@ -16,8 +16,7 @@
     "electron-dl": "^3.2.0",
     "electron-squirrel-startup": "^1.0.0",
     "electron-window-state": "^5.0.3",
-    "source-map-support": "^0.5.19",
-    "tldts": "latest"
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
     "electron": "^12.0.1"

--- a/app/src/helpers/helpers.test.ts
+++ b/app/src/helpers/helpers.test.ts
@@ -5,6 +5,8 @@ const internalUrlWww = 'https://www.medium.com/';
 const sameBaseDomainUrl = 'https://app.medium.com/';
 const internalUrlCoUk = 'https://medium.co.uk/';
 const sameBaseDomainUrlCoUk = 'https://app.medium.co.uk/';
+const sameBaseDomainUrlTidalListen = 'https://listen.tidal.com/';
+const sameBaseDomainUrlTidalLogin = 'https://login.tidal.com/';
 const internalUrlSubPath = 'topic/technology';
 const externalUrl = 'https://www.wikipedia.org/wiki/Electron';
 const wildcardRegex = /.*/;
@@ -45,6 +47,16 @@ test('urls on the same "base domain" should be considered internal, even with a 
   expect(linkIsInternal(internalUrlWww, sameBaseDomainUrl, undefined)).toEqual(
     true,
   );
+});
+
+test('urls on the same "base domain" should be considered internal, even with different sub domains', () => {
+  expect(
+    linkIsInternal(
+      sameBaseDomainUrlTidalListen,
+      sameBaseDomainUrlTidalLogin,
+      undefined,
+    ),
+  ).toEqual(true);
 });
 
 test('urls on the same "base domain" should be considered internal, long SLD', () => {

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -77,6 +77,12 @@ export function linkIsInternal(
   }
 }
 
+/**
+ * Helper to determine domain-ish equality for many cases, the trivial ones
+ * and the trickier ones, e.g. `blog.foo.com` and `shop.foo.com`,
+ * in a way that is "good enough", and doesn't need a list of SLDs.
+ * See chat at https://github.com/nativefier/nativefier/pull/1171#pullrequestreview-649132523
+ */
 function domainify(url: string): string {
   // So here's what we're doing here:
   // Get the hostname from the url

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -59,8 +59,15 @@ export function linkIsInternal(
     // 1. app.foo.com and foo.com
     // 2. www.foo.com and foo.com
     // 3. www.foo.com and app.foo.com
-    const currentDomain = new URL(currentUrl).hostname.replace(/^www\./, '');
-    const newDomain = new URL(newUrl).hostname.replace(/^www./, '');
+
+    // Only use the tld and the main domain for domain-ish test
+    // Enables domain-ish equality for blog.foo.com and shop.foo.com
+    // Also makes the endWith check basically obsolete, === could be used.
+    const currentDomain = new URL(currentUrl).hostname
+      .split('.')
+      .slice(-2)
+      .join('.');
+    const newDomain = new URL(newUrl).hostname.split('.').slice(-2).join('.');
     const [longerDomain, shorterDomain] =
       currentDomain.length > newDomain.length
         ? [currentDomain, newDomain]

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { BrowserWindow } from 'electron';
+import { getDomain } from 'tldts';
 
 const INJECT_CSS_PATH = path.join(__dirname, '..', 'inject/inject.css');
 
@@ -32,7 +33,7 @@ function isInternalLoginPage(url: string): boolean {
     'twitter\\.[a-zA-Z\\.]*/oauth/authenticate', // Twitter
     'appleid\\.apple\\.com/auth/authorize', // Apple
   ];
-  const regex = RegExp(internalLoginPagesArray.join('|'));
+  const regex = new RegExp(internalLoginPagesArray.join('|'));
   return regex.test(url);
 }
 
@@ -50,46 +51,22 @@ export function linkIsInternal(
   }
 
   if (internalUrlRegex) {
-    const regex = RegExp(internalUrlRegex);
+    const regex = new RegExp(internalUrlRegex);
     if (regex.test(newUrl)) {
       return true;
     }
   }
 
-  try {
-    // Consider as "same domain-ish", without TLD/SLD list:
-    // 1. app.foo.com and foo.com
-    // 2. www.foo.com and foo.com
-    // 3. www.foo.com and app.foo.com
+  // `getDomain` command could be extended with valid internal hosts (possibly through the nativefier config?)
+  // const currentDomain = getDomain(currentUrl, { validHosts: ['localhost'] });
+  // const newDomain = getDomain(newUrl, { validHosts: ['localhost'] });
+  const currentDomain = getDomain(currentUrl);
+  const newDomain = getDomain(newUrl);
 
-    // Only use the tld and the main domain for domain-ish test
-    // Enables domain-ish equality for blog.foo.com and shop.foo.com
-    return domainify(currentUrl) === domainify(newUrl);
-  } catch (err) {
-    console.warn(
-      'Failed to parse domains as determining if link is internal. From:',
-      currentUrl,
-      'To:',
-      newUrl,
-      err,
-    );
-    return false;
-  }
-}
-
-function domainify(url: string): string {
-  // So here's what we're doing here:
-  // Get the hostname from the url
-  const hostname = new URL(url).hostname;
-  // Drop the first section if the domain
-  const domain = hostname.split('.').slice(1).join('.');
-  // Check the length, if it's too short, the hostname was probably the domain
-  // Or if the domain doesn't have a . in it we went too far
-  if (domain.length < 6 || domain.split('.').length === 0) {
-    return hostname;
-  }
-  // This SHOULD be the domain, but nothing is 100% guaranteed
-  return domain;
+  // An URL in an incorrect syntax or without a correct domain returns `null`
+  return (
+    currentDomain !== null && newDomain !== null && currentDomain === newDomain
+  );
 }
 
 export function shouldInjectCss(): boolean {


### PR DESCRIPTION
Domain-ish URL test now also covers URLs with different sub-domains
- `https://listen.tidal.com`
- `https://login.tidal.com`