### PR TITLE
App: replace console.xyz calls with loglevel.xyz, with a level controlled by app argv --verbose

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
   ],
   rules: {
+    'no-console': 'error',
     'prettier/prettier': 'error',
     // TODO remove when done killing `any`s and making tsc strict
     '@typescript-eslint/ban-ts-comment': 'off',

--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
   ],
   rules: {
+    'no-console': 'error',
     'prettier/prettier': 'error',
     // TODO remove when done killing `any`s and making tsc strict
     '@typescript-eslint/ban-ts-comment': 'off',

--- a/app/package.json
+++ b/app/package.json
@@ -16,6 +16,7 @@
     "electron-dl": "^3.2.0",
     "electron-squirrel-startup": "^1.0.0",
     "electron-window-state": "^5.0.3",
+    "loglevel": "^1.7.1",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {

--- a/app/src/components/menu.ts
+++ b/app/src/components/menu.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import path from 'path';
 
 import { Menu, clipboard, shell, MenuItemConstructorOptions } from 'electron';
+import * as log from 'loglevel';
 
 type BookmarksLink = {
   type: 'link';
@@ -351,10 +352,7 @@ export function createMenu({
       menuTemplate.splice(menuTemplate.length - 2, 0, bookmarksMenu);
     }
   } catch (err) {
-    console.warn(
-      'Failed to load & parse bookmarks configuration JSON file.',
-      err,
-    );
+    log.error('Failed to load & parse bookmarks configuration JSON file.', err);
   }
 
   const menu = Menu.buildFromTemplate(menuTemplate);

--- a/app/src/components/trayIcon.ts
+++ b/app/src/components/trayIcon.ts
@@ -1,4 +1,5 @@
 import { app, Tray, Menu, ipcMain, nativeImage, BrowserWindow } from 'electron';
+import log from 'loglevel';
 
 import { getAppIcon, getCounterValue, isOSX } from '../helpers/helpers';
 
@@ -23,6 +24,7 @@ export function createTrayIcon(
     }
 
     const onClick = () => {
+      log.debug('onClick');
       if (mainWindow.isVisible()) {
         mainWindow.hide();
       } else {
@@ -44,7 +46,8 @@ export function createTrayIcon(
     appIcon.on('click', onClick);
 
     if (options.counter) {
-      mainWindow.on('page-title-updated', (e, title) => {
+      mainWindow.on('page-title-updated', (event, title) => {
+        log.debug('mainWindow.page-title-updated', { event, title });
         const counterValue = getCounterValue(title);
         if (counterValue) {
           appIcon.setToolTip(`(${counterValue})  ${options.name}`);
@@ -54,6 +57,7 @@ export function createTrayIcon(
       });
     } else {
       ipcMain.on('notification', () => {
+        log.debug('ipcMain.notification');
         if (mainWindow.isFocused()) {
           return;
         }
@@ -61,6 +65,7 @@ export function createTrayIcon(
       });
 
       mainWindow.on('focus', () => {
+        log.debug('mainWindow.focus');
         appIcon.setToolTip(options.name);
       });
     }

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { BrowserWindow } from 'electron';
+import * as log from 'loglevel';
 
 export const INJECT_DIR = path.join(__dirname, '..', 'inject');
 
@@ -67,7 +68,7 @@ export function linkIsInternal(
         : [newDomain, currentDomain];
     return longerDomain.endsWith(shorterDomain);
   } catch (err) {
-    console.warn(
+    log.error(
       'Failed to parse domains as determining if link is internal. From:',
       currentUrl,
       'To:',
@@ -97,7 +98,7 @@ export function getCssToInject(): string {
       path.resolve(path.join(INJECT_DIR, cssFileStat.name)),
     );
   for (const cssFile of cssFiles) {
-    console.log(`Injecting CSS file: ${cssFile}`);
+    log.debug('Injecting CSS file', cssFile);
     const cssFileData = fs.readFileSync(cssFile);
     cssToInject += `/* ${cssFile} */\n\n ${cssFileData}\n\n`;
   }
@@ -111,7 +112,7 @@ export function debugLog(browserWindow: BrowserWindow, message: string): void {
   setTimeout(() => {
     browserWindow.webContents.send('debug', message);
   }, 3000);
-  console.info(message);
+  log.info(message);
 }
 
 export function getAppIcon(): string {

--- a/app/src/helpers/inferFlash.ts
+++ b/app/src/helpers/inferFlash.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import log from 'loglevel';
 import * as path from 'path';
 
 import { isOSX, isWindows, isLinux } from './helpers';
@@ -82,6 +83,6 @@ export function inferFlashPath() {
     return findFlashOnLinux();
   }
 
-  console.warn('Unable to determine OS to infer flash player');
+  log.warn('Unable to determine OS to infer flash player');
   return null;
 }

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -28,6 +28,10 @@ if (require('electron-squirrel-startup')) {
   app.exit();
 }
 
+if (process.argv.indexOf('--verbose') > -1) {
+  log.setLevel('DEBUG');
+}
+
 const appArgs = JSON.parse(fs.readFileSync(APP_ARGS_FILE_PATH, 'utf8'));
 
 // Take in a URL on the command line as an override
@@ -36,9 +40,9 @@ if (process.argv.length > 1) {
   try {
     new URL(maybeUrl);
     appArgs.targetUrl = maybeUrl;
-    console.info('Loading override URL passed as argument:', maybeUrl);
+    log.info('Loading override URL passed as argument:', maybeUrl);
   } catch (err) {
-    console.error(
+    log.error(
       'Not loading override URL passed as argument, because failed to parse:',
       maybeUrl,
     );
@@ -117,20 +121,21 @@ const isRunningMacos = isOSX();
 let currentBadgeCount = 0;
 const setDockBadge = isRunningMacos
   ? (count: number, bounce = false) => {
-      app.dock.setBadge(count.toString());
-      if (bounce && count > currentBadgeCount) app.dock.bounce();
-      currentBadgeCount = count;
-    }
+    app.dock.setBadge(count.toString());
+    if (bounce && count > currentBadgeCount) app.dock.bounce();
+    currentBadgeCount = count;
+  }
   : () => undefined;
 
 app.on('window-all-closed', () => {
-  log.debug('windows-all-closed');
+  log.debug('app.window-all-closed');
   if (!isOSX() || appArgs.fastQuit) {
     app.quit();
   }
 });
 
 app.on('activate', (event, hasVisibleWindows) => {
+  log.debug('app.activate', { event, hasVisibleWindows });
   if (isOSX()) {
     // this is called when the dock is clicked
     if (!hasVisibleWindows) {
@@ -140,7 +145,7 @@ app.on('activate', (event, hasVisibleWindows) => {
 });
 
 app.on('before-quit', () => {
-  log.debug('before-quit');
+  log.debug('app.before-quit');
   // not fired when the close button on the window is clicked
   if (isOSX()) {
     // need to force a quit as a workaround here to simulate the osx app hiding behaviour
@@ -153,15 +158,16 @@ app.on('before-quit', () => {
 });
 
 app.on('will-quit', (event) => {
-  log.debug('will-quit', event);
+  log.debug('app.will-quit', event);
 });
 
 app.on('quit', (event, exitCode) => {
-  log.debug('quit', event, exitCode);
+  log.debug('app.quit', { event, exitCode });
 });
 
 if (appArgs.crashReporter) {
   app.on('will-finish-launching', () => {
+    log.debug('app.will-finish-launching');
     crashReporter.start({
       companyName: appArgs.companyName || '',
       productName: appArgs.name,
@@ -177,6 +183,7 @@ if (shouldQuit) {
   app.quit();
 } else {
   app.on('second-instance', () => {
+    log.debug('app.second-instance');
     if (mainWindow) {
       if (!mainWindow.isVisible()) {
         // try
@@ -193,7 +200,7 @@ if (shouldQuit) {
   if (appArgs.widevine) {
     // @ts-ignore This event only appears on the widevine version of electron, which we'd see at runtime
     app.on('widevine-ready', (version: string, lastVersion: string) => {
-      console.log('widevine-ready', version, lastVersion);
+      log.debug('app.widevine-ready', { version, lastVersion });
       onReady();
     });
 
@@ -201,19 +208,20 @@ if (shouldQuit) {
       // @ts-ignore This event only appears on the widevine version of electron, which we'd see at runtime
       'widevine-update-pending',
       (currentVersion: string, pendingVersion: string) => {
-        console.log(
-          `Widevine ${currentVersion} is ready to be upgraded to ${pendingVersion}`,
-        );
+        log.debug('app.widevine-update-pending', {
+          currentVersion,
+          pendingVersion,
+        });
       },
     );
 
     // @ts-ignore This event only appears on the widevine version of electron, which we'd see at runtime
     app.on('widevine-error', (error: any) => {
-      console.error('WIDEVINE ERROR: ', error);
+      log.error('app.widevine-error', error);
     });
   } else {
     app.on('ready', () => {
-      console.log('ready');
+      log.debug('ready');
       onReady();
     });
   }
@@ -295,10 +303,12 @@ function onReady(): void {
   }
 }
 app.on('new-window-for-tab', () => {
+  log.debug('app.new-window-for-tab');
   mainWindow.emit('new-tab');
 });
 
 app.on('login', (event, webContents, request, authInfo, callback) => {
+  log.debug('app.login', { event, request });
   // for http authentication
   event.preventDefault();
 

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -121,10 +121,10 @@ const isRunningMacos = isOSX();
 let currentBadgeCount = 0;
 const setDockBadge = isRunningMacos
   ? (count: number, bounce = false) => {
-    app.dock.setBadge(count.toString());
-    if (bounce && count > currentBadgeCount) app.dock.bounce();
-    currentBadgeCount = count;
-  }
+      app.dock.setBadge(count.toString());
+      if (bounce && count > currentBadgeCount) app.dock.bounce();
+      currentBadgeCount = count;
+    }
   : () => undefined;
 
 app.on('window-all-closed', () => {

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { ipcRenderer } from 'electron';
+import * as log from 'loglevel';
 
 export const INJECT_DIR = path.join(__dirname, '..', 'inject');
 
@@ -52,11 +53,11 @@ function injectScripts() {
       )
       .map((jsFileStat) => path.join('..', 'inject', jsFileStat.name));
     for (const jsFile of jsFiles) {
-      console.log(`Injecting JS file: ${jsFile}`);
+      log.debug('Injecting JS file', jsFile);
       require(jsFile);
     }
   } catch (error) {
-    console.warn('Error encoutered injecting JS files', error);
+    log.error('Error encoutered injecting JS files', error);
   }
 }
 
@@ -70,10 +71,11 @@ function notifyNotificationClick() {
 setNotificationCallback(notifyNotificationCreate, notifyNotificationClick);
 
 ipcRenderer.on('params', (event, message) => {
+  log.debug('ipcRenderer.params', { event, message });
   const appArgs = JSON.parse(message);
-  console.info('nativefier.json', appArgs);
+  log.info('nativefier.json', appArgs);
 });
 
 ipcRenderer.on('debug', (event, message) => {
-  console.info('debug:', message);
+  log.debug('ipcRenderer.debug', { event, message });
 });

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ci": "npm run lint && npm test",
     "clean": "rimraf lib/ app/lib/ app/dist/",
     "clean:full": "rimraf lib/ app/lib/ app/dist/ app/node_modules/ node_modules/",
-    "lint:fix": "eslint . --fix",
+    "lint:fix": "eslint . --ext .ts --fix",
     "lint:format": "prettier --write 'src/**/*.js' 'app/src/**/*.js'",
     "lint": "eslint . --ext .ts",
     "list-outdated-deps": "npm out; cd app && npm out; true",

--- a/src/build/prepareElectronApp.ts
+++ b/src/build/prepareElectronApp.ts
@@ -113,7 +113,7 @@ async function maybeCopyScripts(srcs: string[], dest: string): Promise<void> {
     }
 
     if (supportedInjectionExtensions.indexOf(path.extname(src)) < 0) {
-      console.log(`Skipping unsupported injection file: ${src}`);
+      log.warn('Skipping unsupported injection file', src);
       continue;
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -302,7 +302,7 @@ if (require.main === module) {
   };
 
   if (!options.targetUrl && !options.upgrade) {
-    console.error(
+    log.error(
       'Nativefier must be called with either a targetUrl or the --upgrade option.',
     );
     commander.help();


### PR DESCRIPTION
In reference to request in https://github.com/nativefier/nativefier/pull/1168/files#r623753290 ,
this PR fixes a lot of the disparity in logging, and fleshes the logging out a bit.