### PR TITLE
Fix crash in preload.js due to 3rd-party 'loglevel' (fix #1175, fix #1176)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,11 @@ module.exports = {
   ],
   rules: {
     'no-console': 'error',
-    'prettier/prettier': 'error',
+    'prettier/prettier': [
+      'error', {
+        'endOfLine': 'auto'
+      }
+    ],
     // TODO remove when done killing `any`s and making tsc strict
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/no-explicit-any': 'off',

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -11,9 +11,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { ipcRenderer } from 'electron';
-import * as log from 'loglevel';
+// import * as log from 'loglevel';
 
 export const INJECT_DIR = path.join(__dirname, '..', 'inject');
+
+// Since the browser doesn't have access to node_modules for loglevel
+const log = console;
 
 /**
  * Patches window.Notification to:

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -11,12 +11,21 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { ipcRenderer } from 'electron';
-// import * as log from 'loglevel';
+
+// Do *NOT* add 3rd-party imports here in preload (except for webpack `externals` like electron).
+// They will work during development, but break in the prod build :-/ .
+// Electron doc isn't explicit about that, so maybe *we*'re doing something wrong.
+// At any rate, that's what we have now. If you want an import here, go ahead, but
+// verify that apps built with a non-devbuild nativefier (installed from tarball) work.
+// Recipe to monkey around this, assuming you git-cloned nativefier in /opt/nativefier/ :
+// cd /opt/nativefier/ && rm -f nativefier-43.1.0.tgz && npm run build && npm pack && mkdir -p ~/n4310/ && cd ~/n4310/ \
+//    && rm -rf ./* && npm i /opt/nativefier/nativefier-43.1.0.tgz && ./node_modules/.bin/nativefier 'google.com'
+// See https://github.com/nativefier/nativefier/issues/1175
+// and https://www.electronjs.org/docs/api/browser-window#new-browserwindowoptions / preload
+
+const log = console; // since we can't have `loglevel` here in preload
 
 export const INJECT_DIR = path.join(__dirname, '..', 'inject');
-
-// Since the browser doesn't have access to node_modules for loglevel
-const log = console;
 
 /**
  * Patches window.Notification to:


### PR DESCRIPTION
Should fix #1175 and #1176 