### PR TITLE
CATALOG.md: build command library (fix #1166)

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -16,8 +16,7 @@ Library commands should be the strict necessary to make an app work. So, for exa
 ### Windows Command
 ```
 nativefier https://outlook.office.com/mail 
---name OutlookWA 
---internal-urls ".*?(outlook.live.com|outlook.office365.com|outlook.office.com|login.microsoftonline.com).*?" 
+--internal-urls ".*?(outlook.live.com|outlook.office365.com|outlook.office.com).*?" 
 --file-download-options "{\"saveAs\": true}" 
 --browserwindow-options "{ \"webPreferences\": { \"webviewTag\": true, \"nodeIntegration\": true, \"nodeIntegrationInSubFrames\": true, \"nativeWindowOpen\": true } }"
 ```
@@ -30,8 +29,7 @@ nativefier https://outlook.office.com/mail
 
 ### Windows Command
 ```
-nativefier https://www.udemy.com/ 
---name Udemy 
+nativefier https://www.udemy.com/  
 --internal-urls ".*?udemy.*?" 
 --file-download-options "{\"saveAs\": true}" 
 --widevine

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,6 +1,6 @@
 # Build Commands Library
 
-Below you'll find a list of build commands contributed from the nativefier community.
+Below you'll find a list of build commands contributed by the Nativefier community. They are here as examples, and to help you nativefy "complicated" apps that ask a bit of elbow grease to work.
 
 If you'd like to add to this catalog, please keep the following in mind:
 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -12,7 +12,6 @@ Below you'll find a list of build commands contributed by the Nativefier communi
 
 ## Outlook Web
 
-### Windows Command
 ```
 nativefier https://outlook.office.com/mail 
 --internal-urls ".*?(outlook.live.com|outlook.office365.com|outlook.office.com).*?" 
@@ -26,7 +25,6 @@ nativefier https://outlook.office.com/mail
 
 ## Udemy
 
-### Windows Command
 ```
 nativefier https://www.udemy.com/  
 --internal-urls ".*?udemy.*?" 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -2,9 +2,8 @@
 
 Below you'll find a list of build commands contributed by the Nativefier community. They are here as examples, and to help you nativefy "complicated" apps that ask a bit of elbow grease to work.
 
-If you'd like to add to this catalog, please keep the following in mind:
-
-Library commands should be the strict necessary to make an app work. So, for example,
+- Only add sites that require something special! No need to document here that `simplesite.com` works with a simple `nativefier simplesite.com` 🙂
+- If you'd like to add to this catalog, please add commands with the *strict necessary* to make an app work. So, for example,
 
 - Yes to have `--widevine` in Udemy. Yes to `--internal-urls` and `--browserwindow-options` for Outlook Web. Yes to a name and icon for both...
 - ... but let's not have all the other flags that are a matter of personal preference (e.g. `--disable-dev-tools` or `--disk-cache-size`).

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,0 +1,42 @@
+# Build Commands Library
+
+Below you'll find a list of build commands contributed from the nativefier community.
+
+If you'd like to add to this catalog, please keep the following in mind:
+
+Library commands should be the strict necessary to make an app work. So, for example,
+
+- Yes to have `--widevine` in Udemy. Yes to `--internal-urls` and `--browserwindow-options` for Outlook Web. Yes to a name and icon for both...
+- ... but let's not have all the other flags that are a matter of personal preference (e.g. `--disable-dev-tools` or `--disk-cache-size`).
+
+* * *
+
+## Outlook Web
+
+### Windows Command
+```
+nativefier https://outlook.office.com/mail 
+--name OutlookWA 
+--internal-urls ".*?(outlook.live.com|outlook.office365.com|outlook.office.com|login.microsoftonline.com).*?" 
+--file-download-options "{\"saveAs\": true}" 
+--browserwindow-options "{ \"webPreferences\": { \"webviewTag\": true, \"nodeIntegration\": true, \"nodeIntegrationInSubFrames\": true, \"nativeWindowOpen\": true } }"
+```
+
+### Notes
+
+`--browserwindow-options` -- This is needed in order to allow the window to pop out when creating/editing an email.
+
+## Udemy
+
+### Windows Command
+```
+nativefier https://www.udemy.com/ 
+--name Udemy 
+--internal-urls ".*?udemy.*?" 
+--file-download-options "{\"saveAs\": true}" 
+--widevine
+```
+
+### Notes
+
+Most videos will work, but to be sure everything works you are better off using the `--widevine` version AND signing the app afterwards. See this post: [#1147 (comment)](https://github.com/nativefier/nativefier/issues/1147#issuecomment-828750362)

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,4 +1,4 @@
-# Build Commands Library
+# Build Commands Catalog
 
 Below you'll find a list of build commands contributed by the Nativefier community. They are here as examples, and to help you nativefy "complicated" apps that ask a bit of elbow grease to work.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ to learn about other command-line flags usable to configure the packaged app.
 To have high-resolution icons used by default for an app/domain, please
 contribute to the [icon repository](https://github.com/nativefier/nativefier-icons)!
 
+### Build Commands Library
+
+For a list of build commands contributed by the nativefier community take a look at the [CATALOG.md file](CATALOG.md)
+
 ## Usage with Docker
 
 Nativefier is also usable from Docker.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to learn about other command-line flags usable to configure the packaged app.
 To have high-resolution icons used by default for an app/domain, please
 contribute to the [icon repository](https://github.com/nativefier/nativefier-icons)!
 
-### Build Commands Library
+### Build Commands Catalog
 
 For a list of build commands contributed by the nativefier community take a look at the [CATALOG.md file](CATALOG.md)
 
@@ -96,6 +96,8 @@ Help welcome on [bugs](https://github.com/nativefier/nativefier/issues?q=is%3Aop
 ## Troubleshooting
 
 Before submitting a question or bug report, please ensure you have read through these common issues and see if you can resolve the problem on your own. If you still encounter issues after trying these steps, or you don't see something similar to your issue listed, please submit a [bug report](https://github.com/nativefier/nativefier/issues/new?assignees=&labels=bug&template=bug_report.md).
+
+Take a look a the [Build Command Catalog](CATALOG.md) as a working command for your application may already exist there.
 
 ### I am trying to use Nativefier to build an app for a site that tells me I have an old/unsupported browser.
 


### PR DESCRIPTION
Added the CATALOG.md file and updated the README.md file Usage section to link to the new file.