### PR TITLE
Fix logging out users on upgrade / app recreate with same URL (fix #1176)

### DIFF
--- a/src/build/prepareElectronApp.test.ts
+++ b/src/build/prepareElectronApp.test.ts
@@ -1,0 +1,11 @@
+import { normalizeAppName } from './prepareElectronApp';
+
+describe('normalizeAppName', () => {
+  test('it is stable', () => {
+    // Non-determinism / unstability would cause using a different appName
+    // at each app regen, thus a different appData folder, which would cause
+    // losing user state, including login state through cookies.
+    const normalizedTrello = normalizeAppName('Trello', 'https://trello.com');
+    expect(normalizedTrello).toBe('trello-nativefier-679e8e');
+  });
+});

--- a/src/build/prepareElectronApp.ts
+++ b/src/build/prepareElectronApp.ts
@@ -129,7 +129,7 @@ async function maybeCopyScripts(srcs: string[], dest: string): Promise<void> {
 }
 
 /**
- * Use a basic 3-character hash to prevent collisions. The hash is deterministic url & name,
+ * Use a basic 6-character hash to prevent collisions. The hash is deterministic url & name,
  * so that an upgrade (same URL) of an app keeps using the same appData folder.
  * Warning! Changing this normalizing & hashing will change the way appNames are generated,
  *          changing appData folder, and users will get logged out of their apps after an upgrade.

--- a/src/build/prepareElectronApp.ts
+++ b/src/build/prepareElectronApp.ts
@@ -127,13 +127,14 @@ async function maybeCopyScripts(srcs: string[], dest: string): Promise<void> {
     await copyFileOrDir(src, destPath);
   }
 }
+
 /**
  * Use a basic 3-character hash to prevent collisions. The hash is deterministic url & name,
  * so that an upgrade (same URL) of an app keeps using the same appData folder.
  * Warning! Changing this normalizing & hashing will change the way appNames are generated,
  *          changing appData folder, and users will get logged out of their apps after an upgrade.
  */
-function normalizeAppName(appName: string, url: string): string {
+export function normalizeAppName(appName: string, url: string): string {
   const hash = crypto.createHash('md5');
   hash.update(url);
   const postFixHash = hash.digest('hex').substring(0, 6);

--- a/src/build/prepareElectronApp.ts
+++ b/src/build/prepareElectronApp.ts
@@ -130,6 +130,8 @@ async function maybeCopyScripts(srcs: string[], dest: string): Promise<void> {
 /**
  * Use a simple 3-character hash to prevent collisions. The hash is deterministic-by-url,
  * so that an upgrade (same URL) of an existing app keeps using the same appData folder.
+ * Warning! Changing this normalizing & hashing will change the way appNames are generated,
+ *          changing appData folder, and users will get logged out of their apps after an upgrade.
  */
 function normalizeAppName(appName: string, url: string): string {
   const hash = crypto.createHash('md5');

--- a/src/build/prepareElectronApp.ts
+++ b/src/build/prepareElectronApp.ts
@@ -128,8 +128,8 @@ async function maybeCopyScripts(srcs: string[], dest: string): Promise<void> {
   }
 }
 /**
- * Use a simple 3-character hash to prevent collisions. The hash is deterministic-by-url,
- * so that an upgrade (same URL) of an existing app keeps using the same appData folder.
+ * Use a basic 3-character hash to prevent collisions. The hash is deterministic url & name,
+ * so that an upgrade (same URL) of an app keeps using the same appData folder.
  * Warning! Changing this normalizing & hashing will change the way appNames are generated,
  *          changing appData folder, and users will get logged out of their apps after an upgrade.
  */


### PR DESCRIPTION
This is a follow-up of https://github.com/nativefier/nativefier/pull/1162#discussion_r623766247

PR #1162 introduced a new `generateRandomSuffix` helper function,
used it for its needs (avoiding collisions of injected js/css).

But it also replaced existing appname normalizing logic with it,
introducing randomness in a place that used to be deterministic.

As a result, starting with dd6e15fb5 / v43.1.0, re-creating an app would cause
the app to use a different appName, thus a different appData folder, thus
losing user data including cookies.

This PR leaves the `--inject` fixes of #1176, but reverts the appName logic
to the pre-#1176 code.