### PR TITLE
CATALOG.md: cleanup & add Google apps section

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -24,7 +24,7 @@ Note: lying about the User Agent is required, else Google will notice your "Chro
 
 ```sh
 nativefier 'https://outlook.office.com/mail'
-  --internal-urls '.*?(outlook.live.com|outlook.office365.com|outlook.office.com).*?'
+  --internal-urls '.*?(outlook.live.com|outlook.office365.com).*?'
   --file-download-options '{"saveAs": true}'
   --browserwindow-options '{"webPreferences": { "webviewTag": true, "nodeIntegration": true, "nodeIntegrationInSubFrames": true, "nativeWindowOpen": true } }'
 ```

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,37 +1,43 @@
 # Build Commands Catalog
 
-Below you'll find a list of build commands contributed by the Nativefier community. They are here as examples, and to help you nativefy "complicated" apps that ask a bit of elbow grease to work.
+Below you'll find a list of build commands contributed by the Nativefier community. They are here as examples, to help you nativefy "complicated" apps that need a bit of elbow grease to work. We need your help to enrich it, as long as you follow these two guidelines:
 
-- Only add sites that require something special! No need to document here that `simplesite.com` works with a simple `nativefier simplesite.com` 🙂
-- If you'd like to add to this catalog, please add commands with the *strict necessary* to make an app work. So, for example,
+1. Only add sites that require something special! No need to document here that `simplesite.com` works with a simple `nativefier simplesite.com` 🙂.
+2. Please add commands with the *strict necessary* to make an app work. For example,
+    - Yes to mention that `--widevine` or some `--browserwindow-options` are necessary...
+    - ... but don't add other flags that are pure personal preference (e.g. `--disable-dev-tools` or `--disk-cache-size`).
 
-- Yes to have `--widevine` in Udemy. Yes to `--internal-urls` and `--browserwindow-options` for Outlook Web. Yes to a name and icon for both...
-- ... but let's not have all the other flags that are a matter of personal preference (e.g. `--disable-dev-tools` or `--disk-cache-size`).
+---
 
-* * *
+## Google apps
 
-## Outlook Web
+(This example documents Google Sheets, but is applicable to other Google apps)
 
+```sh
+nativefier 'https://docs.google.com/spreadsheets' \
+  --user-agent 'user agent of current stable Firefox'
 ```
-nativefier https://outlook.office.com/mail 
---internal-urls ".*?(outlook.live.com|outlook.office365.com|outlook.office.com).*?" 
---file-download-options "{\"saveAs\": true}" 
---browserwindow-options "{ \"webPreferences\": { \"webviewTag\": true, \"nodeIntegration\": true, \"nodeIntegrationInSubFrames\": true, \"nativeWindowOpen\": true } }"
+
+Note: lying about the User Agent is required, else Google will notice your "Chrome" isn't a real Chrome, and will refuse access.
+
+## Outlook
+
+```sh
+nativefier 'https://outlook.office.com/mail'
+  --internal-urls '.*?(outlook.live.com|outlook.office365.com|outlook.office.com).*?'
+  --file-download-options '{"saveAs": true}'
+  --browserwindow-options '{"webPreferences": { "webviewTag": true, "nodeIntegration": true, "nodeIntegrationInSubFrames": true, "nativeWindowOpen": true } }'
 ```
 
-### Notes
-
-`--browserwindow-options` -- This is needed in order to allow the window to pop out when creating/editing an email.
+Note: `--browserwindow-options` is needed to allow pop-outs when creating/editing an email.
 
 ## Udemy
 
-```
-nativefier https://www.udemy.com/  
---internal-urls ".*?udemy.*?" 
---file-download-options "{\"saveAs\": true}" 
---widevine
+```sh
+nativefier 'https://www.udemy.com/'
+  --internal-urls '.*?udemy.*?'
+  --file-download-options '{"saveAs": true}'
+  --widevine
 ```
 
-### Notes
-
-Most videos will work, but to be sure everything works you are better off using the `--widevine` version AND signing the app afterwards. See this post: [#1147 (comment)](https://github.com/nativefier/nativefier/issues/1147#issuecomment-828750362)
+Note: most videos will work, but to play some DRMed videos you must pass `--widevine` AND [sign the app](https://github.com/nativefier/nativefier/issues/1147#issuecomment-828750362).


### PR DESCRIPTION
Google apps hint taken from https://github.com/nativefier/nativefier/issues/831#issuecomment-839899360

Also,

 - copy / cleanup / conciseness
 - commands indentation
 - using single quotes to avoid escaping double-quotes
 - add markdown subsyntax hint for nativefier calls
 - remove subsections for more clarity of sections & more vertical compactness.