### PR TITLE
Bump minimum required version: node>=12.9, npm>=6.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         node-version:
         - 16.x # Changing this? Remind to keep linter conditions below and in publish.yml aligned.
-        - 10.x
+        - 12.x
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,16 @@ jobs:
     strategy:
       matrix:
         node-version:
-        - 16.x # Changing this? Remind to keep linter conditions below and in publish.yml aligned.
+        # Align the top Node version here with: 1. linter conditions later below, 2. publish.yml.
+        - 16.x
+        # Bumping the minimum required Node version? You must bump:
+        #   1. package.json -> engines.node
+        #   2. package.json -> devDependencies.@types/node
+        #   3. tsconfig.json -> {target, lib}
+        #   4. .github/workflows/ci.yml -> node-version
+        #
+        # Here in ci.yml, we want to always run the oldest version we require in
+        # package.json -> engines.node, to be sure Nativefier runs on this minimum
         - 12.x
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ gen
 nativefier*.tgz
 
 .vscode
+
+# https://github.com/nektos/act
+.actrc

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "author": "Goh Jia Hao",
   "engines": {
-    "node": ">= 10.0.0",
-    "npm": ">= 6.0.0"
+    "node": ">= 12.0.0",
+    "npm": ">= 6.9.0"
   },
   "keywords": [
     "desktop",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Wrap web apps natively",
   "license": "MIT",
   "author": "Goh Jia Hao",
+  "engines_README": "Bumping the minimum required Node version? You must bump: 1. package.json -> engines.node, 2. package.json -> devDependencies.@types/node , 3. tsconfig.json -> {target, lib} , 4. .github/workflows/ci.yml -> node-version",
+  "engines_READMEforEnginesNode": "Here in engines.node, we require a version as old as possible, for Nativefier to be easily installable using the stock Node.js shipped by conservative Linux distros. It's a balancing act between this, and our own dependencies requiring more a recent Node; as much as possible, try to keep supporting Debian stable; https://packages.debian.org/search?suite=stable&keywords=nodejs",
   "engines": {
-    "node": ">= 12.0.0",
+    "node": ">= 12.9.0",
     "npm": ">= 6.9.0"
   },
   "keywords": [
@@ -66,7 +68,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.20",
     "@types/ncp": "^2.0.4",
-    "@types/node": "^10.17.55",
+    "@types/node": "^12.12.6",
     "@types/page-icon": "^0.3.3",
     "@types/tmp": "^0.2.0",
     "@typescript-eslint/eslint-plugin": "^4.17.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,10 +9,22 @@
       "resolveJsonModule": true,
       "skipLibCheck": true,
       "sourceMap": true,
-      // https://stackoverflow.com/questions/51716406/typescript-tsconfig-settings-for-node-js-10
-      // and 'dom' to tell tsc it's okay to use the URL object (which is in Node >= 7)
-      "target": "es2018",
-      "lib": ["es2018", "dom"]
+      // Bumping the minimum required Node version? You must bump:
+      //   1. package.json -> engines.node
+      //   2. package.json -> devDependencies.@types/node
+      //   3. tsconfig.json -> {target, lib}
+      //   4. .github/workflows/ci.yml -> node-version
+      //
+      // Here in tsconfig.json, we want to set the `target` and `lib` keys
+      // to the "best" values for the minimum/required version of node.
+      // TS doesn't offer any easy "preset" for this, so the best we have is to
+      // believe people who know which {syntax, library} parts of current EcmaScript
+      // are supported for our version of Node, and use what they recommend.
+      // For the current Node version, I followed
+      // https://stackoverflow.com/questions/59787574/typescript-tsconfig-settings-for-node-js-12
+      "target": "es2019",
+      // In `lib` we add `dom`, to tell tsc it's okay to use the URL object (which is in Node >= 7)
+      "lib": ["es2020", "dom"]
   },
   "include": [
       "./src/**/*"


### PR DESCRIPTION
As Node 10 is deprecated, this PR moves our minimum required version of node to 12.0.0 and npm to 6.9.0 (which is the version of npm that was released with node 12.0.0)