### PR TITLE
Eliminate need for global mainWindow, refactor widevine / non-widevine events

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -98,8 +98,6 @@ if (appArgs.processEnvs) {
   }
 }
 
-let mainWindow: BrowserWindow;
-
 if (typeof appArgs.flashPluginDir === 'string') {
   app.commandLine.appendSwitch('ppapi-flash-path', appArgs.flashPluginDir);
 } else if (appArgs.flashPluginDir) {
@@ -169,16 +167,6 @@ app.on('window-all-closed', () => {
   }
 });
 
-app.on('activate', (event, hasVisibleWindows) => {
-  log.debug('app.activate', { event, hasVisibleWindows });
-  if (isOSX()) {
-    // this is called when the dock is clicked
-    if (!hasVisibleWindows) {
-      mainWindow.show();
-    }
-  }
-});
-
 app.on('before-quit', () => {
   log.debug('app.before-quit');
   // not fired when the close button on the window is clicked
@@ -212,62 +200,100 @@ if (appArgs.crashReporter) {
   });
 }
 
-// quit if singleInstance mode and there's already another instance running
-const shouldQuit = appArgs.singleInstance && !app.requestSingleInstanceLock();
-if (shouldQuit) {
-  app.quit();
+if (appArgs.widevine) {
+  // @ts-ignore This event only appears on the widevine version of electron, which we'd see at runtime
+  app.on('widevine-ready', (version: string, lastVersion: string) => {
+    log.debug('app.widevine-ready', { version, lastVersion });
+    onReady().catch((err) => log.error('onReady ERROR', err));
+  });
+
+  app.on(
+    // @ts-ignore This event only appears on the widevine version of electron, which we'd see at runtime
+    'widevine-update-pending',
+    (currentVersion: string, pendingVersion: string) => {
+      log.debug('app.widevine-update-pending', {
+        currentVersion,
+        pendingVersion,
+      });
+    },
+  );
+
+  // @ts-ignore This event only appears on the widevine version of electron, which we'd see at runtime
+  app.on('widevine-error', (error: any) => {
+    log.error('app.widevine-error', error);
+  });
 } else {
-  app.on('second-instance', () => {
-    log.debug('app.second-instance');
-    if (mainWindow) {
-      if (!mainWindow.isVisible()) {
-        // try
+  app.on('ready', () => {
+    log.debug('ready');
+    onReady().catch((err) => log.error('onReady ERROR', err));
+  });
+}
+
+function initAppWindowEvents(mainWindow: BrowserWindow) {
+  app.on('activate', (event, hasVisibleWindows) => {
+    log.debug('app.activate', { event, hasVisibleWindows });
+    if (isOSX()) {
+      // this is called when the dock is clicked
+      if (!hasVisibleWindows) {
         mainWindow.show();
       }
-      if (mainWindow.isMinimized()) {
-        // minimized
-        mainWindow.restore();
-      }
-      mainWindow.focus();
     }
   });
 
-  if (appArgs.widevine) {
-    // @ts-ignore This event only appears on the widevine version of electron, which we'd see at runtime
-    app.on('widevine-ready', (version: string, lastVersion: string) => {
-      log.debug('app.widevine-ready', { version, lastVersion });
-      onReady().catch((err) => log.error('onReady ERROR', err));
-    });
-
-    app.on(
-      // @ts-ignore This event only appears on the widevine version of electron, which we'd see at runtime
-      'widevine-update-pending',
-      (currentVersion: string, pendingVersion: string) => {
-        log.debug('app.widevine-update-pending', {
-          currentVersion,
-          pendingVersion,
-        });
-      },
-    );
-
-    // @ts-ignore This event only appears on the widevine version of electron, which we'd see at runtime
-    app.on('widevine-error', (error: any) => {
-      log.error('app.widevine-error', error);
-    });
+  // quit if singleInstance mode and there's already another instance running
+  const shouldQuit = appArgs.singleInstance && !app.requestSingleInstanceLock();
+  if (shouldQuit) {
+    app.quit();
   } else {
-    app.on('ready', () => {
-      log.debug('ready');
-      onReady().catch((err) => log.error('onReady ERROR', err));
+    app.on('second-instance', () => {
+      log.debug('app.second-instance');
+      if (mainWindow) {
+        if (!mainWindow.isVisible()) {
+          // try
+          mainWindow.show();
+        }
+        if (mainWindow.isMinimized()) {
+          // minimized
+          mainWindow.restore();
+        }
+        mainWindow.focus();
+      }
     });
   }
+
+  app.on('new-window-for-tab', () => {
+    log.debug('app.new-window-for-tab');
+    if (mainWindow) {
+      mainWindow.emit('new-tab');
+    }
+  });
+
+  app.on('login', (event, webContents, request, authInfo, callback) => {
+    log.debug('app.login', { event, request });
+    // for http authentication
+    event.preventDefault();
+
+    if (
+      appArgs.basicAuthUsername !== null &&
+      appArgs.basicAuthPassword !== null
+    ) {
+      callback(appArgs.basicAuthUsername, appArgs.basicAuthPassword);
+    } else {
+      createLoginWindow(callback, mainWindow).catch((err) =>
+        log.error('createLoginWindow ERROR', err),
+      );
+    }
+  });
 }
 
 async function onReady(): Promise<void> {
-  mainWindow = await createMainWindow(
+  const mainWindow = await createMainWindow(
     appArgs,
     app.quit.bind(this),
     setDockBadge,
   );
+
+  initAppWindowEvents(mainWindow);
 
   createTrayIcon(appArgs, mainWindow);
 
@@ -343,29 +369,6 @@ async function onReady(): Promise<void> {
       .catch((err) => log.error('dialog.showMessageBox ERROR', err));
   }
 }
-app.on('new-window-for-tab', () => {
-  log.debug('app.new-window-for-tab');
-  if (mainWindow) {
-    mainWindow.emit('new-tab');
-  }
-});
-
-app.on('login', (event, webContents, request, authInfo, callback) => {
-  log.debug('app.login', { event, request });
-  // for http authentication
-  event.preventDefault();
-
-  if (
-    appArgs.basicAuthUsername !== null &&
-    appArgs.basicAuthPassword !== null
-  ) {
-    callback(appArgs.basicAuthUsername, appArgs.basicAuthPassword);
-  } else {
-    createLoginWindow(callback, mainWindow).catch((err) =>
-      log.error('createLoginWindow ERROR', err),
-    );
-  }
-});
 
 app.on(
   'accessibility-support-changed',


### PR DESCRIPTION
@ronjouch this PR probably seems like overkill but it accomplishes two things:

- Eliminating the global mainWindow variable so weird scoping bugs like this can't happen
- More importantly: I also discovered a bug where the widevine events and non-widevine ready event were embedded within an unrelated if/else block. See: https://github.com/nativefier/nativefier/blob/72de7b3/app/src/main.ts#L235-L262 and look at their parent if/else block.