### PR TITLE
Selective css injection

### DIFF
--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -179,11 +179,3 @@ export function removeUserAgentSpecifics(
     .replace(`Electron/${process.versions.electron} `, '')
     .replace(`${appName}/${appVersion} `, ' ');
 }
-
-export function shouldInjectCSS(): boolean {
-  try {
-    return fs.existsSync(INJECT_DIR);
-  } catch (e) {
-    return false;
-  }
-}

--- a/app/src/helpers/windowHelpers.ts
+++ b/app/src/helpers/windowHelpers.ts
@@ -241,7 +241,7 @@ async function injectCSSIntoResponse(
   details: OnHeadersReceivedListenerDetails,
   cssToInject: string,
 ): Promise<Record<string, string[]>> {
-  const nonInjectableMethods = ['DELETE', 'OPTIONS', 'PATCH', 'POST', 'PUT'];
+  const nonInjectableMethods = ['DELETE', 'OPTIONS'];
   const nonInjectableResourceTypes = [
     'image',
     'other',

--- a/app/src/helpers/windowHelpers.ts
+++ b/app/src/helpers/windowHelpers.ts
@@ -236,6 +236,8 @@ async function injectCSSIntoResponse(
   details: OnHeadersReceivedListenerDetails,
   cssToInject: string,
 ): Promise<Record<string, string[]>> {
+  // We go with a denylist rather than a whitelist (e.g. only GET/html)
+  // to avoid "whoops I didn't think this should have been CSS-injected" cases
   const nonInjectableMethods = ['DELETE', 'OPTIONS'];
   const nonInjectableResourceTypes = ['image', 'script', 'stylesheet', 'xhr'];
 

--- a/app/src/helpers/windowHelpers.ts
+++ b/app/src/helpers/windowHelpers.ts
@@ -10,12 +10,7 @@ import {
 
 import log from 'loglevel';
 import path from 'path';
-import {
-  getCSSToInject,
-  isOSX,
-  nativeTabsSupported,
-  shouldInjectCSS,
-} from './helpers';
+import { getCSSToInject, isOSX, nativeTabsSupported } from './helpers';
 
 const ZOOM_INTERVAL = 0.1;
 
@@ -198,11 +193,11 @@ export function hideWindow(
 }
 
 export function injectCSS(browserWindow: BrowserWindow): void {
-  if (!shouldInjectCSS()) {
+  const cssToInject = getCSSToInject();
+
+  if (!cssToInject) {
     return;
   }
-
-  const cssToInject = getCSSToInject();
 
   browserWindow.webContents.on('did-navigate', () => {
     log.debug(
@@ -226,7 +221,7 @@ export function injectCSS(browserWindow: BrowserWindow): void {
             });
           })
           .catch((err) => {
-            log.error('winjectCSSIntoResponse ERROR', err);
+            log.error('injectCSSIntoResponse ERROR', err);
             callback({
               cancel: false,
               responseHeaders: details.responseHeaders,
@@ -242,13 +237,7 @@ async function injectCSSIntoResponse(
   cssToInject: string,
 ): Promise<Record<string, string[]>> {
   const nonInjectableMethods = ['DELETE', 'OPTIONS'];
-  const nonInjectableResourceTypes = [
-    'image',
-    'other',
-    'script',
-    'stylesheet',
-    'xhr',
-  ];
+  const nonInjectableResourceTypes = ['image', 'script', 'stylesheet', 'xhr'];
 
   if (
     nonInjectableMethods.includes(details.method) ||


### PR DESCRIPTION
When debugging other issues recently, I noticed that we are VERY aggressive with trying to inject CSS. This came in a few forms:

- We try to inject CSS as long as we have an inject directory (regardless of whether there is CSS in it), which now seems to always return true as we have a placeholder file in there now.
- We try to inject CSS on ANY network call (whether CSS is relevant or not).

So this PR tweaks this so that we will now:
- Check for actual CSS to see if we have anything to inject
- Check the http method and resource type of the requests we're monitoring and blacklist the following from CSS injection as unnecessary:
    - METHOD: DELETE
    - MEtHOD: OPTIONS
    - RESOURCE TYPE: image
    - RESOURCE TYPE: script
    - RESOURCE TYPE: stylesheet
    - RESOURCE TYPE: xhr
- Add unit tests for these

I chose the blacklist approach rather than whitelist (such as only `GET` method and `html` resource type) so that we can eliminate as many "whoops I didn't think that needed CSS" as possible.