### PR TITLE
Fix badge/counter icon not being removed correctly (fixes #1251)

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -169,7 +169,7 @@ if (appArgs.lang) {
 let currentBadgeCount = 0;
 const setDockBadge = isOSX()
   ? (count?: number | string, bounce = false): void => {
-      if (count) {
+      if (typeof count !== 'undefined') {
         app.dock.setBadge(count.toString());
         if (bounce && count > currentBadgeCount) app.dock.bounce();
         currentBadgeCount = typeof count === 'number' ? count : 0;

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -169,7 +169,7 @@ if (appArgs.lang) {
 let currentBadgeCount = 0;
 const setDockBadge = isOSX()
   ? (count?: number | string, bounce = false): void => {
-      if (typeof count !== 'undefined') {
+      if (count !== undefined) {
         app.dock.setBadge(count.toString());
         if (bounce && count > currentBadgeCount) app.dock.bounce();
         currentBadgeCount = typeof count === 'number' ? count : 0;


### PR DESCRIPTION
The current check for `count` means the value to reset/remove the badge (`''`) is treated as `false` and therefore the badge does not get removed. This PR changes the check for `undefined` instead which resolves the issue. 

Related issue: 
https://github.com/nativefier/nativefier/issues/1251

Testing performed:
- I ran `npm t` as per the docs. All tests passed. 
- I created a new app build for Twitter (`https://twitter.com`) and Messenger (`https://messenger.com`) to verify the correct behaviour. Both were showed the issue as resolved. 