### PR TITLE
Fix notification broken since Nativefier 43 / Electron 12 defaulting to contextIsolation:true

### DIFF
--- a/app/src/helpers/windowHelpers.ts
+++ b/app/src/helpers/windowHelpers.ts
@@ -148,6 +148,7 @@ export function getDefaultWindowOptions(
       plugins: true,
       webSecurity: !options.insecure,
       zoomFactor: options.zoom,
+      contextIsolation: false,
       ...webPreferences,
     },
     ...browserwindowOptions,


### PR DESCRIPTION
Notification events are broken. Probably by bumping the Electron version and not handling required changes.
window.Notification is not shared with BrowserWindow and preload if contextIsolation is set. 