### PR TITLE
Use userAgentFallback for userAgent  injection

### DIFF
--- a/app/src/helpers/windowEvents.ts
+++ b/app/src/helpers/windowEvents.ts
@@ -171,10 +171,6 @@ export function setupNativefierWindow(
   options: WindowOptions,
   window: BrowserWindow,
 ): void {
-  if (options.userAgent) {
-    window.webContents.userAgent = options.userAgent;
-  }
-
   if (options.proxyRules) {
     setProxyRules(window, options.proxyRules);
   }

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -59,11 +59,15 @@ if (appArgs.portable) {
 }
 
 if (!appArgs.userAgentHonest) {
-  app.userAgentFallback = removeUserAgentSpecifics(
-    app.userAgentFallback,
-    app.getName(),
-    app.getVersion(),
-  );
+  if (appArgs.userAgent) {
+    app.userAgentFallback = appArgs.userAgent;
+  } else {
+    app.userAgentFallback = removeUserAgentSpecifics(
+      app.userAgentFallback,
+      app.getName(),
+      app.getVersion(),
+    );
+  }
 }
 
 // Take in a URL on the command line as an override


### PR DESCRIPTION
@ronjouch per the suggestion of @fireflinchdev , this seems to alleviate our issues with things like nuking service workers for WhatsApp. The core reason being those service workers were getting the original userAgent, and not the override (if specified). This PR should fix that.

So it should resolve #1312 #719 and hopefully a few future issues as this seems to come up frequently.