### PR TITLE
Add getDisplayMedia and PipeWire support

### DIFF
--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -224,13 +224,11 @@ function setupCounter(
 }
 
 function setupSessionPermissionHandler(window: BrowserWindow): void {
-  window.webContents.session.setPermissionCheckHandler(
-    (_webContents, _permission, _details) => {
-      return true;
-    },
-  );
+  window.webContents.session.setPermissionCheckHandler(() => {
+    return true;
+  });
   window.webContents.session.setPermissionRequestHandler(
-    (_webContents, _permission, callback, _details) => {
+    (_webContents, _permission, callback) => {
       callback(true);
     },
   );

--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -224,12 +224,16 @@ function setupCounter(
 }
 
 function setupSessionPermissionHandler(window: BrowserWindow): void {
-  window.webContents.session.setPermissionCheckHandler((_webContents, _permission, _details) => {
-    return true;
-  });
-  window.webContents.session.setPermissionRequestHandler(async (_webContents, _permission, callback, _details) => {
-    callback(true);
-  });
+  window.webContents.session.setPermissionCheckHandler(
+    (_webContents, _permission, _details) => {
+      return true;
+    },
+  );
+  window.webContents.session.setPermissionRequestHandler(
+    async (_webContents, _permission, callback, _details) => {
+      callback(true);
+    },
+  );
 }
 
 function setupNotificationBadge(

--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -230,7 +230,7 @@ function setupSessionPermissionHandler(window: BrowserWindow): void {
     },
   );
   window.webContents.session.setPermissionRequestHandler(
-    async (_webContents, _permission, callback, _details) => {
+    (_webContents, _permission, callback, _details) => {
       callback(true);
     },
   );

--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -143,6 +143,7 @@ export async function createMainWindow(
   });
 
   setupSessionInteraction(options, mainWindow);
+  setupSessionPermissionHandler(mainWindow);
 
   if (options.clearCache) {
     await clearCache(mainWindow);
@@ -219,6 +220,15 @@ function setupCounter(
     } else {
       setDockBadge('');
     }
+  });
+}
+
+function setupSessionPermissionHandler(window: BrowserWindow): void {
+  window.webContents.session.setPermissionCheckHandler((_webContents, _permission, _details) => {
+    return true;
+  });
+  window.webContents.session.setPermissionRequestHandler(async (_webContents, _permission, callback, _details) => {
+    callback(true);
   });
 }
 

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { spawnSync as nodeSpawnSync } from 'node:child_process';
 
 import { BrowserWindow, OpenExternalOptions, shell } from 'electron';
 import * as log from 'loglevel';
@@ -164,6 +165,15 @@ export function openExternal(
 ): Promise<void> {
   log.debug('openExternal', { url, options });
   return shell.openExternal(url, options);
+}
+
+export function isWayland(): boolean {
+  return isLinux() && spawnSync('echo', ['$XDG_SESSION_TYPE']).includes('wayland');
+}
+
+export function spawnSync(cmd: string, args: string[]): string {
+  const result = nodeSpawnSync(cmd, args, { encoding: 'utf-8' });
+  return result.stdout;
 }
 
 export function removeUserAgentSpecifics(

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -167,7 +167,11 @@ export function openExternal(
 }
 
 export function isWayland(): boolean {
-  return isLinux() && (Boolean(process.env.WAYLAND_DISPLAY) || process.env.XDG_SESSION_TYPE === 'wayland'); 
+  return (
+    isLinux() &&
+    (Boolean(process.env.WAYLAND_DISPLAY) ||
+      process.env.XDG_SESSION_TYPE === 'wayland')
+  );
 }
 
 export function removeUserAgentSpecifics(

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -167,7 +167,7 @@ export function openExternal(
 }
 
 export function isWayland(): boolean {
-  return isLinux() && process.env.XDG_SESSION_TYPE === 'wayland'; 
+  return isLinux() && (Boolean(process.env.WAYLAND_DISPLAY) || process.env.XDG_SESSION_TYPE === 'wayland'); 
 }
 
 export function removeUserAgentSpecifics(

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { spawnSync as nodeSpawnSync } from 'node:child_process';
 
 import { BrowserWindow, OpenExternalOptions, shell } from 'electron';
 import * as log from 'loglevel';
@@ -168,12 +167,7 @@ export function openExternal(
 }
 
 export function isWayland(): boolean {
-  return isLinux() && spawnSync('echo', ['$XDG_SESSION_TYPE']).includes('wayland');
-}
-
-export function spawnSync(cmd: string, args: string[]): string {
-  const result = nodeSpawnSync(cmd, args, { encoding: 'utf-8' });
-  return result.stdout;
+  return isLinux() && process.env.XDG_SESSION_TYPE === 'wayland'; 
 }
 
 export function removeUserAgentSpecifics(

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -22,7 +22,7 @@ import {
   createMainWindow,
 } from './components/mainWindow';
 import { createTrayIcon } from './components/trayIcon';
-import { isOSX, removeUserAgentSpecifics } from './helpers/helpers';
+import { isOSX, isWayland, removeUserAgentSpecifics } from './helpers/helpers';
 import { inferFlashPath } from './helpers/inferFlash';
 import { setupNativefierWindow } from './helpers/windowEvents';
 import {
@@ -156,6 +156,10 @@ if (appArgs.basicAuthPassword) {
     'basic-auth-password',
     appArgs.basicAuthPassword,
   );
+}
+
+if (isWayland()) {
+  app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer');
 }
 
 if (appArgs.lang) {

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -86,13 +86,19 @@ function setupScreenSharePickerStyles(id: string): void {
   screenShareStyles.id = id;
   screenShareStyles.innerHTML = `
   .desktop-capturer-selection {
+    --overlay-color: hsla(0, 0%, 11.8%, 0.75);
+    --highlight-color: highlight;
+    --text-content-color: #fff;
+    --selection-button-color: hsl(180, 1.3%, 14.7%);
+  }
+  .desktop-capturer-selection {
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
     height: 100vh;
-    background: rgba(30,30,30,.75);
-    color: #fff;
+    background: var(--overlay-color);
+    color: var(--text-content-color);
     z-index: 10000000;
     display: flex;
     align-items: center;
@@ -103,7 +109,7 @@ function setupScreenSharePickerStyles(id: string): void {
     -webkit-appearance: none;
     appearance: none;
     padding: 1rem;
-    color: #fff;
+    color: inherit;
     position: absolute;
     left: 1rem;
     top: 1rem;
@@ -137,13 +143,13 @@ function setupScreenSharePickerStyles(id: string): void {
     border: 0;
     border-radius: 3px;
     padding: 4px;
-    background: #252626;
+    background: var(--selection-button-color);
     text-align: left;
     transition: background-color .15s, box-shadow .15s;
   }
   .desktop-capturer-selection__btn:hover,
   .desktop-capturer-selection__btn:focus {
-    background: rgba(98,100,167,.8);
+    background: var(--highlight-color);
   }
   .desktop-capturer-selection__thumbnail {
     width: 100%;
@@ -155,6 +161,13 @@ function setupScreenSharePickerStyles(id: string): void {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+  }
+  @media (prefers-color-scheme: light) {
+    .desktop-capturer-selection {
+      --overlay-color: hsla(0, 0%, 90.2%, 0.75);
+      --text-content-color: hsl(0, 0%, 12.9%);
+      --selection-button-color: hsl(180, 1.3%, 85.3%);
+    }
   }`;
   document.head.appendChild(screenShareStyles);
 }

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -225,6 +225,7 @@ function setupScreenSharePicker(
     .getElementById(`${baseElementsId}-close`)
     ?.addEventListener('click', () => {
       clearElements();
+      reject('Screen share was cancelled by the user.');
     });
 
   document

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -164,12 +164,12 @@ function setupScreenSharePickerElement(
   selectionElem.classList.add('desktop-capturer-selection');
   selectionElem.id = id;
   selectionElem.innerHTML = `
+    <button class="desktop-capturer-selection__close" id="${id}-close" aria-label="Close screen share picker" type="button">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32">
+      <path fill="currentColor" d="m12 10.586 4.95-4.95 1.414 1.414-4.95 4.95 4.95 4.95-1.414 1.414-4.95-4.95-4.95 4.95-1.414-1.414 4.95-4.95-4.95-4.95L7.05 5.636z"/>   
+      </svg>
+    </button>
     <div class="desktop-capturer-selection__scroller">
-      <button class="desktop-capturer-selection__close" id="${id}-close" aria-label="Close screen share picker" type="button">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32">
-        <path fill="currentColor" d="m12 10.586 4.95-4.95 1.414 1.414-4.95 4.95 4.95 4.95-1.414 1.414-4.95-4.95-4.95 4.95-1.414-1.414 4.95-4.95-4.95-4.95L7.05 5.636z"/>   
-        </svg>
-      </button>
       <ul class="desktop-capturer-selection__list">
         ${sources.map(({ id, name, thumbnail }) => `
           <li class="desktop-capturer-selection__item">


### PR DESCRIPTION
This will, in theory, fix #927 . I made this from a new environment, my personal computer, where I don't use teams, so it's not tested yet, but it should work, as I've made these changes on my work laptop and worked flawlessly.

Some notes:
- As commented on lines 238-239 in preload.ts, choosing screen/window to share with PipeWire may not be deterministic, I'm taking a guess, because I tested it n my work laptop and it always returns what PipeWire-screen-share-picker returns, that is what the user chooses to share;
- Not tested on Mac;
- The permissions handler (`setupSessionPermissionHandler`) is, in my opinion, a bad thing. Electron is not "safe by default", and force permission to get this working is not a good idea... Unfortunately we don't have another option as of this moment. Also see: https://github.com/electron/electron/issues/12931;
- Picker should handle accessibility properly;
- On wayland, using pipewire and DE Gnome, if the user clicks on "stop sharing" in the top right corner, next to the system menu and tray icons (if setup), it doesn't stop sharing, but the icon to stop sharing in Gnome disappears. I honestly don't know how to handle this.

Screen share icon mentioned in the last item from the previous list:
![grafik](https://user-images.githubusercontent.com/23178554/144694955-312bfba1-0f3e-41f2-a9ab-62a06bb60ed8.png)
