### PR TITLE
Add "quiet" option to suppress all log output

### DIFF
--- a/API.md
+++ b/API.md
@@ -81,6 +81,7 @@
   - [Debug Options](#debug-options)
     - [[crash-reporter]](#crash-reporter)
     - [[verbose]](#verbose)
+    - [[quiet]](#quiet)
   - [Flash Options (Deprecated)](#flash-options-deprecated)
     - [[flash] and [flash-path] (DEPRECATED)](#flash-and-flash-path-deprecated)
 - [Programmatic API](#programmatic-api)
@@ -102,6 +103,7 @@ nativefier [options] [targetUrl] [dest]
 ```
 
 You must provide:
+
 - Either a `targetUrl` to generate a new app from it.
 - Or option `--upgrade <pathOfAppToUpgrade>` to upgrade an existing app.
 
@@ -142,12 +144,12 @@ Prints the version of your `nativefier` install.
 The processor architecture to target when building.
 
 - Default: the architecture of the installed version of node (usually the architecture of the build-time machine).
-    - To test your default architecture you can run
-      ```
-      node -p "process.arch"
-      ```
-      (See https://nodejs.org/api/os.html#os_os_arch)
-    - Please note: On M1 Macs, unless an arm64 version of brew is used to install nodejs, the version installed will be an `x64` version run through Rosetta, and will result in an `x64` app being generated. If this is not desired, either specify `-a arm64` to build for M1, or re-install node with an arm64 version of brew. See https://github.com/nativefier/nativefier/issues/1089
+  - To test your default architecture you can run
+    ```
+    node -p "process.arch"
+    ```
+    (See https://nodejs.org/api/os.html#os_os_arch)
+  - Please note: On M1 Macs, unless an arm64 version of brew is used to install nodejs, the version installed will be an `x64` version run through Rosetta, and will result in an `x64` app being generated. If this is not desired, either specify `-a arm64` to build for M1, or re-install node with an arm64 version of brew. See https://github.com/nativefier/nativefier/issues/1089
 - Can be overridden by specifying one of: `ia32`, `x64`, `armv7l`, `arm64`.
 
 Note: careful to not conflate _platform_ with _architecture_. If you want for example a Linux or Mac build, it's `--platform` you are looking for. See its documentation for details.
@@ -210,11 +212,11 @@ Specifies if the destination directory should be not overwritten, defaults to fa
 ```
 
 - Default: current operating system.
-    - To test your default platform you can run
-      ```
-      node -p "process.platform"
-      ```
-      (See https://nodejs.org/api/os.html#os_os_platform)
+  - To test your default platform you can run
+    ```
+    node -p "process.platform"
+    ```
+    (See https://nodejs.org/api/os.html#os_os_platform)
 - Can be overwritten by specifying either `linux`, `windows`, `osx` or `mas` for a Mac App Store specific build.
 
 Note: careful to not conflate _platform_ with _architecture_. If you want for example a 32bit build or an ARM build, it's `--arch` you are looking for. See its documentation for details.
@@ -227,11 +229,11 @@ For backwards compatibility, less-clear values `win32` (for Windows) and `darwin
 --portable
 ```
 
-*[New in 43.1.0]* Make your app store its user data (cookies, cache, etc) inside the app folder, making it "portable" in the sense popularized by [PortableApps.com](https://portableapps.com/): you can carry it around e.g. on a USB key, and it will work the same with your data.
+_[New in 43.1.0]_ Make your app store its user data (cookies, cache, etc) inside the app folder, making it "portable" in the sense popularized by [PortableApps.com](https://portableapps.com/): you can carry it around e.g. on a USB key, and it will work the same with your data.
 
-*IMPORTANT SECURITY NOTICE*: when creating a portable app, all data accumulated after running the app (including login information, cache, cookies), will be saved in the app folder. If this app is then shared with others, THEY WILL HAVE THAT ACCUMULATED DATA, POTENTIALLY INCLUDING ACCESS TO ANY ACCOUNTS YOU LOGGED INTO.
+_IMPORTANT SECURITY NOTICE_: when creating a portable app, all data accumulated after running the app (including login information, cache, cookies), will be saved in the app folder. If this app is then shared with others, THEY WILL HAVE THAT ACCUMULATED DATA, POTENTIALLY INCLUDING ACCESS TO ANY ACCOUNTS YOU LOGGED INTO.
 
-→ Best practice to *distribute apps* using this flag:
+→ Best practice to _distribute apps_ using this flag:
 
 1. Create your application with this flag
 2. Test it
@@ -245,9 +247,9 @@ For backwards compatibility, less-clear values `win32` (for Windows) and `darwin
 --upgrade <pathToExistingApp>
 ```
 
-*[New in 43.1.0]* This option will attempt to extract all existing options from the old app, and upgrade it using the current Nativefier CLI.
+_[New in 43.1.0]_ This option will attempt to extract all existing options from the old app, and upgrade it using the current Nativefier CLI.
 
-*Important data safety note*: This action is an in-place upgrade, and will REPLACE the current application. In case this feature does not work as intended or as the user may wish, it is advised to make a backup of the app to be upgraded before using, or specify an alternate directory as you would when creating a new file.**
+_Important data safety note_: This action is an in-place upgrade, and will REPLACE the current application. In case this feature does not work as intended or as the user may wish, it is advised to make a backup of the app to be upgraded before using, or specify an alternate directory as you would when creating a new file.\*\*
 
 The provided path must be the "executable" of an application packaged with a previous version of Nativefier, and to be upgraded to the latest version of Nativefier. "Executable" means: the `.exe` file on Windows, the executable on Linux, or the `.app` on macOS. The executable must be living in the original context where it was generated (i.e., on Windows and Linux, the exe file must still be in the folder containing the generated `resources` directory).
 
@@ -257,7 +259,7 @@ The provided path must be the "executable" of an application packaged with a pre
 --widevine
 ```
 
-*[New in 11.0.2]* Use a Widevine-enabled version of Electron for DRM playback, see https://github.com/castlabs/electron-releases.
+_[New in 11.0.2]_ Use a Widevine-enabled version of Electron for DRM playback, see https://github.com/castlabs/electron-releases.
 
 Note: some sites using Widevine (like Udemy or HBO Max) may still refuse to load videos, and require EVS-signing your Nativefier app to work. Try signing your app using CastLabs tools. See https://github.com/castlabs/electron-releases/wiki/EVS and [#1147](https://github.com/nativefier/nativefier/issues/1147#issuecomment-828750362). TL;DR:
 
@@ -280,7 +282,7 @@ python -m castlabs_evs.vmp sign-pkg Udemy-win32-x64
 --always-on-top
 ```
 
-*[New in 7.6.0]* Enable always on top for the packaged application.
+_[New in 7.6.0]_ Enable always on top for the packaged application.
 
 #### [background-color]
 
@@ -288,7 +290,7 @@ python -m castlabs_evs.vmp sign-pkg Udemy-win32-x64
 --background-color <string>
 ```
 
-*[New in 7.7.0]* See https://electronjs.org/docs/api/browser-window#setting-backgroundcolor
+_[New in 7.7.0]_ See https://electronjs.org/docs/api/browser-window#setting-backgroundcolor
 
 #### [bookmarks-menu]
 
@@ -296,7 +298,7 @@ python -m castlabs_evs.vmp sign-pkg Udemy-win32-x64
 --bookmarks-menu <string>
 ```
 
-*[New in 43.1.0]* Path to a JSON file defining a bookmarks menu. In addition to containing a list of bookmarks, this file customizes the name of the menu and (optionally) allows assigning keyboard shortcuts to bookmarks.
+_[New in 43.1.0]_ Path to a JSON file defining a bookmarks menu. In addition to containing a list of bookmarks, this file customizes the name of the menu and (optionally) allows assigning keyboard shortcuts to bookmarks.
 
 This menu is a simple list; folders are not supported.
 
@@ -308,31 +310,30 @@ Example of such a JSON file:
 
 ```json
 {
-    "menuLabel": "&Music",
-    "bookmarks": [
-        {
-            "title": "lofi.cafe",
-            "url": "https://lofi.cafe/",
-            "type": "link",
-            "shortcut": "CmdOrCtrl+1"
-        },
-        {
-            "title": "beats to relax/study to",
-            "url": "https://www.youtube.com/watch?v=5qap5aO4i9A",
-            "type": "link",
-            "shortcut": "CmdOrCtrl+2"
-        },
-        {
-            "type": "separator"
-        },
-        {
-            "title": "RÜFÜS DU SOL Live from Joshua Tree",
-            "type": "link",
-            "url": "https://www.youtube.com/watch?v=Zy4KtD98S2c"
-        }
-    ]
+  "menuLabel": "&Music",
+  "bookmarks": [
+    {
+      "title": "lofi.cafe",
+      "url": "https://lofi.cafe/",
+      "type": "link",
+      "shortcut": "CmdOrCtrl+1"
+    },
+    {
+      "title": "beats to relax/study to",
+      "url": "https://www.youtube.com/watch?v=5qap5aO4i9A",
+      "type": "link",
+      "shortcut": "CmdOrCtrl+2"
+    },
+    {
+      "type": "separator"
+    },
+    {
+      "title": "RÜFÜS DU SOL Live from Joshua Tree",
+      "type": "link",
+      "url": "https://www.youtube.com/watch?v=Zy4KtD98S2c"
+    }
+  ]
 }
-
 ```
 
 #### [browserwindow-options]
@@ -341,7 +342,7 @@ Example of such a JSON file:
 --browserwindow-options <json-string>
 ```
 
-*[New in 7.7.0]* A JSON string that will be sent directly into Electron BrowserWindow options.
+_[New in 7.7.0]_ A JSON string that will be sent directly into Electron BrowserWindow options.
 See [Electron's BrowserWindow API Documentation](https://electronjs.org/docs/api/browser-window#new-browserwindowoptions) for the complete list of options.
 
 Example:
@@ -466,7 +467,7 @@ Prevents application from being run multiple times. If such an attempt occurs th
 --title-bar-style <value>
 ```
 
-*[New in 7.6.4]* (macOS only) Sets the style for the app's title bar. See more details at electron's [Frameless Window](https://github.com/electron/electron/blob/master/docs/api/frameless-window.md#alternatives-on-macos) documentation.
+_[New in 7.6.4]_ (macOS only) Sets the style for the app's title bar. See more details at electron's [Frameless Window](https://github.com/electron/electron/blob/master/docs/api/frameless-window.md#alternatives-on-macos) documentation.
 
 Consider injecting a custom CSS (via `--inject`) for better integration. Specifically, the CSS should specify a draggable region. For instance, if the target website has a `<header>` element, you can make it draggable like so.
 
@@ -500,7 +501,7 @@ nativefier http://google.com --inject site.css --title-bar-style 'hiddenInset'
 --tray [start-in-tray]
 ```
 
-*[New in 7.5.0]* Application will stay as an icon in the system tray. Prevents application from being closed from clicking the window close button.
+_[New in 7.5.0]_ Application will stay as an icon in the system tray. Prevents application from being closed from clicking the window close button.
 
 When the optional argument `start-in-tray` is provided, i.e. the application is started using `--tray start-in-tray`, the main window will not be shown on first start.
 
@@ -528,7 +529,7 @@ X location of the packaged application window.
 --y <value>
 ```
 
-*[New in 7.6.0]* Y location of the packaged application window.
+_[New in 7.6.0]_ Y location of the packaged application window.
 
 #### [zoom]
 
@@ -536,7 +537,7 @@ X location of the packaged application window.
 --zoom <value>
 ```
 
-*[New in 7.6.0]* Sets a default zoom factor to be used when the app is opened, defaults to `1.0`.
+_[New in 7.6.0]_ Sets a default zoom factor to be used when the app is opened, defaults to `1.0`.
 
 ### Internal Browser Options
 
@@ -546,7 +547,7 @@ X location of the packaged application window.
 --file-download-options <json-string>
 ```
 
-*[New in 7.6.0]* A JSON string of key/value pairs to be set as file download options. See [electron-dl](https://github.com/sindresorhus/electron-dl) for available options.
+_[New in 7.6.0]_ A JSON string of key/value pairs to be set as file download options. See [electron-dl](https://github.com/sindresorhus/electron-dl) for available options.
 
 Example:
 
@@ -560,7 +561,7 @@ nativefier <your-website> --file-download-options '{"saveAs": true}'
 --global-shortcuts shortcuts.json
 ```
 
-*[New in 7.6.9]* Register global shortcuts which will trigger input events like key presses or pointer events in the application.
+_[New in 7.6.9]_ Register global shortcuts which will trigger input events like key presses or pointer events in the application.
 
 You may define multiple global shortcuts which can trigger a series of input events. It has the following structure:
 
@@ -582,12 +583,12 @@ You may define multiple global shortcuts which can trigger a series of input eve
 ];
 ```
 
-*Note regarding modifier keys:* If you want to trigger key events which include a modifier (Ctrl, Shift,...), you need to keyDown the modifier key first, then keyDown the actual key _including_ the modifier key as modifier property and then keyUp both keys again. No idea what this means? See the example for `MediaPreviousTrack` below! For more details, please see the Electron documentation:
+_Note regarding modifier keys:_ If you want to trigger key events which include a modifier (Ctrl, Shift,...), you need to keyDown the modifier key first, then keyDown the actual key _including_ the modifier key as modifier property and then keyUp both keys again. No idea what this means? See the example for `MediaPreviousTrack` below! For more details, please see the Electron documentation:
 
 - List of available keys: https://github.com/electron/electron/blob/master/docs/api/accelerator.md
 - Details about how to create input event objects: https://github.com/electron/electron/blob/master/docs/api/web-contents.md#contentssendinputeventevent
 
-*Note about Global Shortcuts on macOS*
+_Note about Global Shortcuts on macOS_
 
 On MacOS 10.14+, if you have set a global shortcut that includes a Media key, the user will need to be prompted for permissions to enable these keys in System Preferences > Security & Privacy > Accessibility.
 
@@ -687,7 +688,7 @@ Set the language or locale to render the web site as (e.g., "fr", "en-US", "es",
 
 Set the user agent to run the created app with. Use `--user-agent-honest` to use the true Electron user agent.
 
-*[New in 44.0.0]* The following short codes are also supported to generate a user agent: `edge`, `firefox`, `safari`.
+_[New in 44.0.0]_ The following short codes are also supported to generate a user agent: `edge`, `firefox`, `safari`.
 
 - `edge` will generate a Microsoft Edge user agent matching the Chrome version of Electron being used
 - `firefox` will generate a Mozilla Firefox user agent matching the latest stable release of that browser
@@ -711,7 +712,7 @@ If this flag is passed, it will not override the user agent, and use Electron's 
 --clear-cache
 ```
 
-*[New in 7.6.11]* Prevents the application from preserving cache between launches.
+_[New in 7.6.11]_ Prevents the application from preserving cache between launches.
 
 #### [disk-cache-size]
 
@@ -719,7 +720,7 @@ If this flag is passed, it will not override the user agent, and use Electron's 
 --disk-cache-size <value>
 ```
 
-*[New in 7.4.1]* Forces the maximum disk space to be used by the disk cache. Value is given in bytes.
+_[New in 7.4.1]_ Forces the maximum disk space to be used by the disk cache. Value is given in bytes.
 
 ### URL Handling Options
 
@@ -750,6 +751,7 @@ Internal URLs will open in Nativefier, other URLs will open in your preferred br
 
 Defaults to view as "internal" two URLs that share the same base domain,
 once stripped of `www.`. For example, by default,
+
 - URLs from/to `foo.com`, `app.foo.com`, `www.foo.com` are considered internal.
 - URLs from/to `abc.com` and `xyz.com` are considered external.
 
@@ -767,13 +769,14 @@ nativefier https://google.com --internal-urls ".*?"
 
 ##### Internal Login Pages
 
-*[New in 43.0.0]* Finally, URLs for known login pages
+_[New in 43.0.0]_ Finally, URLs for known login pages
 are considered internal. This does not replace `internal-urls`, it complements
-it, and happens *before* your `internal-urls` rule is applied. So, if you
+it, and happens _before_ your `internal-urls` rule is applied. So, if you
 already set the flag to let such auth pages open internally, you don't need to
 change it but it might be unnecessary.
 
 Current known internal login pages:
+
 - `amazon.com/signin`
 - `appleid.apple.com/auth/authorize`
 - `id.atlassian.com` , `auth.atlassian.com`
@@ -796,7 +799,7 @@ If you think this list is missing a login page that you think should be internal
 --proxy-rules <value>
 ```
 
-*[New in 7.7.1]* See [Electron proxyRules](https://electronjs.org/docs/api/session?q=proxy#sessetproxyconfig-callback) for more details.
+_[New in 7.7.1]_ See [Electron proxyRules](https://electronjs.org/docs/api/session?q=proxy#sessetproxyconfig-callback) for more details.
 
 Example:
 
@@ -812,7 +815,7 @@ nativefier https://google.com --proxy-rules http://127.0.0.1:1080
 --basic-auth-username <value> --basic-auth-password <value>
 ```
 
-*[New in 7.5.0]* Set basic http(s) auth via the command line to have the app automatically log you in to a protected site. Both fields are required if one is set.
+_[New in 7.5.0]_ Set basic http(s) auth via the command line to have the app automatically log you in to a protected site. Both fields are required if one is set.
 
 ### Graphics Options
 
@@ -822,7 +825,7 @@ nativefier https://google.com --proxy-rules http://127.0.0.1:1080
 --disable-gpu
 ```
 
-*[New in 7.6.2]* Disable hardware acceleration for the packaged application.
+_[New in 7.6.2]_ Disable hardware acceleration for the packaged application.
 
 #### [enable-es3-apis]
 
@@ -830,7 +833,7 @@ nativefier https://google.com --proxy-rules http://127.0.0.1:1080
 --enable-es3-apis
 ```
 
-*[New in 7.4.1]* Passes the enable-es3-apis flag to the Chrome engine, to force the activation of WebGl 2.0.
+_[New in 7.4.1]_ Passes the enable-es3-apis flag to the Chrome engine, to force the activation of WebGl 2.0.
 
 #### [ignore-gpu-blacklist]
 
@@ -838,7 +841,7 @@ nativefier https://google.com --proxy-rules http://127.0.0.1:1080
 --ignore-gpu-blacklist
 ```
 
-*[New in 7.4.1]* Passes the ignore-gpu-blacklist flag to the Chrome engine, to allow for WebGl apps to work on non supported graphics cards.
+_[New in 7.4.1]_ Passes the ignore-gpu-blacklist flag to the Chrome engine, to allow for WebGl apps to work on non supported graphics cards.
 
 ### (In)Security Options
 
@@ -874,7 +877,7 @@ Forces the packaged app to ignore web security errors, such as [Mixed Content](h
 --app-copyright <value>
 ```
 
-*[New in 7.5.0]* The human-readable copyright line for the app. Maps to the `LegalCopyright` metadata property on Windows, and `NSHumanReadableCopyright` on OS X.
+_[New in 7.5.0]_ The human-readable copyright line for the app. Maps to the `LegalCopyright` metadata property on Windows, and `NSHumanReadableCopyright` on OS X.
 
 #### [app-version]
 
@@ -882,7 +885,7 @@ Forces the packaged app to ignore web security errors, such as [Mixed Content](h
 --app-version <value>
 ```
 
-*[New in 7.5.0]* (macOS and Windows only) The release version of the application. By default the `version` property in the `package.json` is used but it can be overridden with this argument. If neither are provided, the version of Electron will be used. Maps to the `ProductVersion` metadata property on Windows, and `CFBundleShortVersionString` on OS X.
+_[New in 7.5.0]_ (macOS and Windows only) The release version of the application. By default the `version` property in the `package.json` is used but it can be overridden with this argument. If neither are provided, the version of Electron will be used. Maps to the `ProductVersion` metadata property on Windows, and `CFBundleShortVersionString` on OS X.
 
 #### [bounce]
 
@@ -890,7 +893,7 @@ Forces the packaged app to ignore web security errors, such as [Mixed Content](h
 --bounce
 ```
 
-*[New in 7.6.2]* (macOS only) When the counter increases, the dock icon will bounce for one second. This only works if the `--counter` option is active.
+_[New in 7.6.2]_ (macOS only) When the counter increases, the dock icon will bounce for one second. This only works if the `--counter` option is active.
 
 #### [build-version]
 
@@ -898,7 +901,7 @@ Forces the packaged app to ignore web security errors, such as [Mixed Content](h
 --build-version <value>
 ```
 
-*[New in 7.5.0]* (macOS and Windows only) The build version of the application. Maps to the `FileVersion` metadata property on Windows, and `CFBundleVersion` on OS X.
+_[New in 7.5.0]_ (macOS and Windows only) The build version of the application. Maps to the `FileVersion` metadata property on Windows, and `CFBundleVersion` on OS X.
 
 #### [counter]
 
@@ -948,6 +951,14 @@ nativefier http://google.com --crash-reporter https://electron-crash-reporter.ap
 
 Shows detailed logs in the console.
 
+#### [quiet]
+
+```
+--quiet
+```
+
+Suppress all log output. If both `verbose` and `quiet` are passed to the CLI, `verbose` will take precedence.
+
 #### [win32metadata]
 
 ```
@@ -966,7 +977,7 @@ nativefier <your-geolocation-enabled-website> --win32metadata '{"ProductName": "
 
 #### [flash] and [flash-path] (DEPRECATED)
 
-*DEPRECATED as of 2021-03-10, will be removed at some point*: There's nothing Nativefier can do to stop this treadmill, so here it goes.
+_DEPRECATED as of 2021-03-10, will be removed at some point_: There's nothing Nativefier can do to stop this treadmill, so here it goes.
 Flash is triply dead upstream: at Adobe, in Chrome, and now in Electron.
 Nativefier 43.0.0 was just released, and defaults to Electron 12, which
 [removes support for Flash](https://www.electronjs.org/blog/electron-12-0#breaking-changes):
@@ -1110,9 +1121,7 @@ const electron = require('electron');
 
 const request = {
   func: 'setDownloadPath',
-  funcArgs: [
-    `/home/user/downloads`,
-  ],
+  funcArgs: [`/home/user/downloads`],
 };
 electron.ipcRenderer.send('session-interaction', request);
 ```
@@ -1136,7 +1145,7 @@ const request = {
 electron.ipcRenderer.send('session-interaction', request);
 
 electon.ipcRenderer.on('session-interaction-reply', (event, result) => {
-    console.log('session-interaction-reply', event, result.value)
+  console.log('session-interaction-reply', event, result.value);
 });
 ```
 
@@ -1150,7 +1159,9 @@ const electron = require('electron');
 const request = {
   property: 'availableSpellCheckerLanguages',
 };
-console.log(electron.ipcRenderer.sendSync('session-interaction', request).value);
+console.log(
+  electron.ipcRenderer.sendSync('session-interaction', request).value,
+);
 ```
 
 ### Request IDs
@@ -1167,7 +1178,7 @@ const request = {
 electron.ipcRenderer.send('session-interaction', request);
 
 electon.ipcRenderer.on('session-interaction-reply', (event, result) => {
-    console.log('session-interaction-reply', event, result.id, result.value)
+  console.log('session-interaction-reply', event, result.id, result.value);
 });
 ```
 
@@ -1179,10 +1190,12 @@ If an error occurs while handling the interaction, it will be returned in the `s
 const electron = require('electron');
 
 electron.ipcRenderer.on('session-interaction-reply', (event, result) => {
-    console.log('session-interaction-reply', event, result.error)
+  console.log('session-interaction-reply', event, result.error);
 });
 
-electron.ipcRenderer.send('session-interaction', { func: 'thisFunctionDoesNotExist' });
+electron.ipcRenderer.send('session-interaction', {
+  func: 'thisFunctionDoesNotExist',
+});
 ```
 
 ### Complex Return Values
@@ -1192,7 +1205,6 @@ Due to the nature of how these events are transmitted back and forth, session fu
 For example, the following code will return an error instead of the expected value:
 
 ```javascript
-
 const electron = require('electron');
 
 const request = {
@@ -1202,7 +1214,7 @@ const request = {
 electron.ipcRenderer.send('session-interaction', request);
 
 electon.ipcRenderer.on('session-interaction-reply', (event, result) => {
-  console.log('session-interaction-reply', event, result)
+  console.log('session-interaction-reply', event, result);
 });
 ```
 
@@ -1214,37 +1226,58 @@ This javascript, when injected as a file via `--inject`, will attempt to call th
 const electron = require('electron');
 
 electron.ipcRenderer.on('session-interaction-reply', (event, result) => {
-    console.log('session-interaction-reply', event, result);
-    switch (result.id) {
-        case 'isSpellCheckerEnabled':
-            console.log('SpellChecker enabled?', result.value);
-            if (result.value === true) {
-                console.log("Getting supported languages...");
-                electron.ipcRenderer.send('session-interaction', { id: 'availableSpellCheckerLanguages', property: 'availableSpellCheckerLanguages', });
-            } else {
-                console.log("SpellChecker disabled. Enabling...");
-                electron.ipcRenderer.send('session-interaction', { id: 'setSpellCheckerEnabled', property: 'spellCheckerEnabled', propertyValue: true, });
-            }
-            break;
-        case 'setSpellCheckerEnabled':
-            console.log('SpellChecker has now been enabled. Getting supported languages...');
-            electron.ipcRenderer.send('session-interaction', { id: 'availableSpellCheckerLanguages', property: 'availableSpellCheckerLanguages', });
-            break;
-        case 'availableSpellCheckerLanguages':
-            console.log('Avaliable spellChecker languages:', result.value);
-            if (result.value.indexOf('fr') > -1) {
-                electron.ipcRenderer.send('session-interaction', { id: 'setSpellCheckerLanguages', func: 'setSpellCheckerLanguages', funcArgs: [['fr']], });
-            } else {
-                console.log("Not changing spellChecker language. 'fr' is not supported.");
-            }
-            break;
-        case 'setSpellCheckerLanguages':
-            console.log('SpellChecker language was set.');
-            break;
-        default:
-            console.error("Unknown reply id:", result.id);
-    }
+  console.log('session-interaction-reply', event, result);
+  switch (result.id) {
+    case 'isSpellCheckerEnabled':
+      console.log('SpellChecker enabled?', result.value);
+      if (result.value === true) {
+        console.log('Getting supported languages...');
+        electron.ipcRenderer.send('session-interaction', {
+          id: 'availableSpellCheckerLanguages',
+          property: 'availableSpellCheckerLanguages',
+        });
+      } else {
+        console.log('SpellChecker disabled. Enabling...');
+        electron.ipcRenderer.send('session-interaction', {
+          id: 'setSpellCheckerEnabled',
+          property: 'spellCheckerEnabled',
+          propertyValue: true,
+        });
+      }
+      break;
+    case 'setSpellCheckerEnabled':
+      console.log(
+        'SpellChecker has now been enabled. Getting supported languages...',
+      );
+      electron.ipcRenderer.send('session-interaction', {
+        id: 'availableSpellCheckerLanguages',
+        property: 'availableSpellCheckerLanguages',
+      });
+      break;
+    case 'availableSpellCheckerLanguages':
+      console.log('Avaliable spellChecker languages:', result.value);
+      if (result.value.indexOf('fr') > -1) {
+        electron.ipcRenderer.send('session-interaction', {
+          id: 'setSpellCheckerLanguages',
+          func: 'setSpellCheckerLanguages',
+          funcArgs: [['fr']],
+        });
+      } else {
+        console.log(
+          "Not changing spellChecker language. 'fr' is not supported.",
+        );
+      }
+      break;
+    case 'setSpellCheckerLanguages':
+      console.log('SpellChecker language was set.');
+      break;
+    default:
+      console.error('Unknown reply id:', result.id);
+  }
 });
 
-electron.ipcRenderer.send('session-interaction', { id: 'isSpellCheckerEnabled', func: 'isSpellCheckerEnabled', });
+electron.ipcRenderer.send('session-interaction', {
+  id: 'isSpellCheckerEnabled',
+  func: 'isSpellCheckerEnabled',
+});
 ```

--- a/shared/src/options/model.ts
+++ b/shared/src/options/model.ts
@@ -54,6 +54,7 @@ export interface AppOptions {
     nativefierVersion: string;
     processEnvs?: string;
     proxyRules?: string;
+    quiet?: boolean;
     showMenuBar: boolean;
     singleInstance: boolean;
     titleBarStyle?: TitleBarValue;
@@ -179,6 +180,7 @@ export type RawOptions = {
   portable?: boolean;
   processEnvs?: string;
   proxyRules?: string;
+  quiet?: boolean;
   showMenuBar?: boolean;
   singleInstance?: boolean;
   targetUrl?: string;

--- a/src/build/buildNativefierApp.ts
+++ b/src/build/buildNativefierApp.ts
@@ -129,6 +129,7 @@ function trimUnprocessableOptions(options: AppOptions): void {
 export async function buildNativefierApp(
   rawOptions: RawOptions,
 ): Promise<string | undefined> {
+  // early-suppress potential logging before full options handling
   if (rawOptions.quiet) {
     log.setLevel('silent');
   }

--- a/src/build/buildNativefierApp.ts
+++ b/src/build/buildNativefierApp.ts
@@ -129,6 +129,10 @@ function trimUnprocessableOptions(options: AppOptions): void {
 export async function buildNativefierApp(
   rawOptions: RawOptions,
 ): Promise<string | undefined> {
+  if (rawOptions.quiet) {
+    log.setLevel('silent');
+  }
+
   log.warn(
     '\n\n    Hi! Nativefier is minimally maintained these days, and needs more hands.\n' +
       '    If you have the time & motivation, help with bugfixes and maintenance is VERY welcome.\n' +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -506,8 +506,13 @@ export function initArgs(argv: string[]): yargs.Argv<RawOptions> {
       description: 'enable verbose/debug/troubleshooting logs',
       type: 'boolean',
     })
+    .option('quiet', {
+      default: false,
+      description: 'suppress all logging',
+      type: 'boolean',
+    })
     .group(
-      ['crash-reporter', 'verbose'],
+      ['crash-reporter', 'verbose', 'quiet'],
       decorateYargOptionGroup('Debug Options'),
     )
     .version()
@@ -654,6 +659,8 @@ if (require.main === module) {
       'Running in verbose mode! This will produce a mountain of logs and',
       'is recommended only for troubleshooting or if you like Shakespeare.',
     );
+  } else if (options.quiet) {
+    log.setLevel('silent');
   } else {
     log.setLevel('info');
   }

--- a/src/options/optionsMain.ts
+++ b/src/options/optionsMain.ts
@@ -48,6 +48,7 @@ export async function getOptions(rawOptions: RawOptions): Promise<AppOptions> {
       name: typeof rawOptions.name === 'string' ? rawOptions.name : '',
       out: rawOptions.out ?? process.cwd(),
       overwrite: rawOptions.overwrite,
+      quiet: rawOptions.quiet ?? false,
       platform: rawOptions.platform,
       portable: rawOptions.portable ?? false,
       targetUrl:
@@ -99,6 +100,7 @@ export async function getOptions(rawOptions: RawOptions): Promise<AppOptions> {
       lang: rawOptions.lang,
       maximize: rawOptions.maximize ?? false,
       nativefierVersion: packageJson.version,
+      quiet: rawOptions.quiet ?? false,
       processEnvs: rawOptions.processEnvs,
       proxyRules: rawOptions.proxyRules,
       showMenuBar: rawOptions.showMenuBar ?? false,
@@ -139,7 +141,7 @@ export async function getOptions(rawOptions: RawOptions): Promise<AppOptions> {
       'is recommended only for troubleshooting or if you like Shakespeare.',
     );
   } else {
-    log.setLevel('info');
+    log.setLevel(options.nativefier.quiet ? 'silent' : 'info');
   }
 
   let requestedElectronBefore16 = false;

--- a/src/options/optionsMain.ts
+++ b/src/options/optionsMain.ts
@@ -140,8 +140,10 @@ export async function getOptions(rawOptions: RawOptions): Promise<AppOptions> {
       'Running in verbose mode! This will produce a mountain of logs and',
       'is recommended only for troubleshooting or if you like Shakespeare.',
     );
+  } else if (options.nativefier.quiet) {
+    log.setLevel('silent');
   } else {
-    log.setLevel(options.nativefier.quiet ? 'silent' : 'info');
+    log.setLevel('info');
   }
 
   let requestedElectronBefore16 = false;


### PR DESCRIPTION
In working on my own repo [hop](https://github.com/Nickersoft/hop), which uses nativefier under-the-hood, I found it very troublesome to suppress log output when using the programmatic API. This PR just adds a quick "quiet" option which will set the log level to "silent" and suppress all electron and nativefier output (except for errors, of course).

Let me know if there are any additional changes I need to make to get this merged!