### PR TITLE
Fixes ignored --file-download-options

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import yargs from 'yargs';
 
 import { DEFAULT_ELECTRON_VERSION } from './constants';
 import {
+  camelCased,
   checkInternet,
   getProcessEnvs,
   isArgFormatInvalid,
@@ -582,6 +583,8 @@ export function parseArgs(args: yargs.Argv<RawOptions>): RawOptions {
   ]) {
     if (parsed[arg] && typeof parsed[arg] === 'string') {
       parsed[arg] = parseJson(parsed[arg] as string);
+      // also set camel-cased option keys
+      parsed[camelCased(arg)] = parsed[arg];
     }
   }
   if (parsed['process-envs'] && typeof parsed['process-envs'] === 'string') {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -583,7 +583,9 @@ export function parseArgs(args: yargs.Argv<RawOptions>): RawOptions {
   ]) {
     if (parsed[arg] && typeof parsed[arg] === 'string') {
       parsed[arg] = parseJson(parsed[arg] as string);
-      // also set camel-cased option keys
+      // sets fileDownloadOptions and browserWindowOptions
+      // as parsed object as they were still strings in `nativefier.json`
+      // because only their snake-cased variants were being parsed above
       parsed[camelCased(arg)] = parsed[arg];
     }
   }

--- a/src/helpers/helpers.test.ts
+++ b/src/helpers/helpers.test.ts
@@ -1,4 +1,8 @@
-import { isArgFormatInvalid, generateRandomSuffix } from './helpers';
+import {
+  isArgFormatInvalid,
+  generateRandomSuffix,
+  camelCased,
+} from './helpers';
 
 describe('isArgFormatInvalid', () => {
   test('is false for correct short args', () => {
@@ -54,5 +58,27 @@ describe('generateRandomSuffix', () => {
 
   test('respects the length param', () => {
     expect(generateRandomSuffix(10).length).toBe(10);
+  });
+});
+
+describe('camelCased', () => {
+  test('has no hyphens in camel case', () => {
+    expect(camelCased('file-download')).toEqual(expect.not.stringMatching(/-/));
+  });
+
+  test('returns camel cased string', () => {
+    expect(camelCased('file-download')).toBe('fileDownload');
+  });
+
+  test('has no spaces in camel case', () => {
+    expect(camelCased('--file--download--')).toBe('fileDownload');
+  });
+
+  test('handles multiple hyphens properly', () => {
+    expect(camelCased('file--download--options')).toBe('fileDownloadOptions');
+  });
+
+  test('does not affect non-snake cased strings', () => {
+    expect(camelCased('win32options')).toBe('win32options');
   });
 });

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -184,3 +184,17 @@ export function checkInternet(): void {
     }
   });
 }
+
+/**
+ * Takes in a snake-cased string and converts to camelCase
+ */
+export function camelCased(str: string): string {
+  return str
+    .split('-')
+    .filter((s) => s.length > 0)
+    .map((word, i) => {
+      if (i === 0) return word;
+      return `${word[0].toUpperCase()}${word.substring(1)}`;
+    })
+    .join('');
+}


### PR DESCRIPTION
This fixes #1275 by assigning camel cased options in parsed arguments in the `parseArgs` function.