### PR TITLE
Feature: Add "copy as plain text" in edit menu (fix #1144)

### DIFF
--- a/app/src/components/menu.ts
+++ b/app/src/components/menu.ts
@@ -10,11 +10,7 @@ import {
 } from 'electron';
 import * as log from 'loglevel';
 
-import {
-  getPlainTextWithoutFormatting,
-  isOSX,
-  openExternal,
-} from '../helpers/helpers';
+import { cleanupPlainText, isOSX, openExternal } from '../helpers/helpers';
 import {
   clearAppData,
   getCurrentURL,
@@ -102,8 +98,9 @@ export function generateMenu(
         label: 'Copy as Plain Text',
         accelerator: 'CmdOrCtrl+Shift+C',
         click: (): void => {
+          // We use clipboard.readText to strip down formatting
           const text = clipboard.readText('selection');
-          clipboard.writeText(getPlainTextWithoutFormatting(text), 'clipboard');
+          clipboard.writeText(cleanupPlainText(text), 'clipboard');
         },
       },
       {

--- a/app/src/components/menu.ts
+++ b/app/src/components/menu.ts
@@ -10,7 +10,11 @@ import {
 } from 'electron';
 import * as log from 'loglevel';
 
-import { isOSX, openExternal } from '../helpers/helpers';
+import {
+  getPlainTextWithoutFormatting,
+  isOSX,
+  openExternal,
+} from '../helpers/helpers';
 import {
   clearAppData,
   getCurrentURL,
@@ -98,11 +102,8 @@ export function generateMenu(
         label: 'Copy as Plain Text',
         accelerator: 'CmdOrCtrl+Shift+C',
         click: (): void => {
-          let text = clipboard.readText('selection');
-          if (text) {
-            text = text.replace(/\n/g, ' ').replace(/\s+/g, ' ');
-          }
-          clipboard.writeText(text, 'clipboard');
+          const text = clipboard.readText('selection');
+          clipboard.writeText(getPlainTextWithoutFormatting(text), 'clipboard');
         },
       },
       {

--- a/app/src/components/menu.ts
+++ b/app/src/components/menu.ts
@@ -95,6 +95,17 @@ export function generateMenu(
         role: 'copy',
       },
       {
+        label: 'Copy as Plain Text',
+        accelerator: 'CmdOrCtrl+Shift+C',
+        click: (): void => {
+          let text = clipboard.readText('selection');
+          if (text) {
+            text = text.replace(/\n/g, ' ').replace(/\s+/g, ' ');
+          }
+          clipboard.writeText(text, 'clipboard');
+        },
+      },
+      {
         label: 'Copy Current URL',
         accelerator: 'CmdOrCtrl+L',
         click: (): void => clipboard.writeText(getCurrentURL()),

--- a/app/src/helpers/helpers.test.ts
+++ b/app/src/helpers/helpers.test.ts
@@ -2,7 +2,7 @@ import {
   linkIsInternal,
   getCounterValue,
   removeUserAgentSpecifics,
-  getPlainTextWithoutFormatting,
+  cleanupPlainText,
 } from './helpers';
 
 const internalUrl = 'https://medium.com/';
@@ -263,26 +263,8 @@ describe('removeUserAgentSpecifics', () => {
   });
 });
 
-describe('getPlainTextWithoutFormatting', () => {
+describe('cleanupPlainText', () => {
   test('removes extra spaces from text', () => {
-    expect(getPlainTextWithoutFormatting('  this is a  test  ')).toBe(
-      'this is a test',
-    );
-  });
-  test('removes newlines from text', () => {
-    expect(
-      getPlainTextWithoutFormatting(`
-    this is a
-    test
-    `),
-    ).toBe('this is a test');
-  });
-  test('removes newlines and from text', () => {
-    expect(
-      getPlainTextWithoutFormatting(`
-        this is a  
-    test  
-    `),
-    ).toBe('this is a test');
+    expect(cleanupPlainText('  this is a  test  ')).toBe('this is a test');
   });
 });

--- a/app/src/helpers/helpers.test.ts
+++ b/app/src/helpers/helpers.test.ts
@@ -2,6 +2,7 @@ import {
   linkIsInternal,
   getCounterValue,
   removeUserAgentSpecifics,
+  getPlainTextWithoutFormatting,
 } from './helpers';
 
 const internalUrl = 'https://medium.com/';
@@ -259,5 +260,29 @@ describe('removeUserAgentSpecifics', () => {
     ).not.toBe(
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.128 Safari/537.36',
     );
+  });
+});
+
+describe('getPlainTextWithoutFormatting', () => {
+  test('removes extra spaces from text', () => {
+    expect(getPlainTextWithoutFormatting('  this is a  test  ')).toBe(
+      'this is a test',
+    );
+  });
+  test('removes newlines from text', () => {
+    expect(
+      getPlainTextWithoutFormatting(`
+    this is a
+    test
+    `),
+    ).toBe('this is a test');
+  });
+  test('removes newlines and from text', () => {
+    expect(
+      getPlainTextWithoutFormatting(`
+        this is a  
+    test  
+    `),
+    ).toBe('this is a test');
   });
 });

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -186,7 +186,7 @@ export function removeUserAgentSpecifics(
     .replace(`${appName}/${appVersion} `, ' ');
 }
 
-// Removes extra spaces from a text
+/** Removes extra spaces from a text */
 export function cleanupPlainText(text: string): string {
   return text.trim().replace(/\s+/g, ' ');
 }

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -185,3 +185,8 @@ export function removeUserAgentSpecifics(
     .replace(`Electron/${process.versions.electron} `, '')
     .replace(`${appName}/${appVersion} `, ' ');
 }
+
+// Removes formatting from a text
+export function getPlainTextWithoutFormatting(text: string): string {
+  return text.replace(/\n/g, ' ').replace(/\s+/g, ' ');
+}

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -186,7 +186,7 @@ export function removeUserAgentSpecifics(
     .replace(`${appName}/${appVersion} `, ' ');
 }
 
-// Removes formatting from a text
-export function getPlainTextWithoutFormatting(text: string): string {
-  return text.trim().replace(/\n/g, ' ').replace(/\s+/g, ' ');
+// Removes extra spaces from a text
+export function cleanupPlainText(text: string): string {
+  return text.trim().replace(/\s+/g, ' ');
 }

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -188,5 +188,5 @@ export function removeUserAgentSpecifics(
 
 // Removes formatting from a text
 export function getPlainTextWithoutFormatting(text: string): string {
-  return text.replace(/\n/g, ' ').replace(/\s+/g, ' ');
+  return text.trim().replace(/\n/g, ' ').replace(/\s+/g, ' ');
 }


### PR DESCRIPTION
This closes #1144 by adding a "Copy as plain text" function in Edit menu.