### PR TITLE
Strip LRM and RLM in linux names (fix #1361)

### DIFF
--- a/src/utils/sanitizeFilename.ts
+++ b/src/utils/sanitizeFilename.ts
@@ -11,7 +11,7 @@ export function sanitizeFilename(
 
   // spaces will cause problems with Ubuntu when pinned to the dock
   if (platform === 'linux') {
-    result = result.replace(/\s/g, '');
+    result = result.replace(/[\s\u200e\u200f]/g, '');
   }
 
   if (!result || result === '') {


### PR DESCRIPTION
On Linux (SUSE at least), if `--name` isn't provided and is inferred,
the filename is prepended with the control character
LRM (https://en.wikipedia.org/wiki/Left-to-right_mark) and I'd assume
RLM for anyone who's using that setting.

This PR strips those control characters out of the file name.