### PR TITLE
Remove extra whitespace in UserAgent (fix #1357)

### DIFF
--- a/app/src/helpers/helpers.test.ts
+++ b/app/src/helpers/helpers.test.ts
@@ -248,9 +248,9 @@ test('getCounterValue should return a string for large counter numbers in the ti
 });
 
 describe('removeUserAgentSpecifics', () => {
+  const userAgentFallback =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) app-nativefier-804458/1.0.0 Chrome/89.0.4389.128 Electron/12.0.7 Safari/537.36';
   test('removes Electron and App specific info', () => {
-    const userAgentFallback =
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) app-nativefier-804458/1.0.0 Chrome/89.0.4389.128 Electron/12.0.7 Safari/537.36';
     expect(
       removeUserAgentSpecifics(
         userAgentFallback,
@@ -261,6 +261,18 @@ describe('removeUserAgentSpecifics', () => {
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.128 Safari/537.36',
     );
   });
+	
+	test('should not have multiple spaces in a row', () => {
+    expect(
+      removeUserAgentSpecifics(
+        userAgentFallback,
+        'app-nativefier-804458',
+        '1.0.0',
+      ),
+		).toEqual(expect.not.stringMatching(
+			/\s{2,}/
+    ));
+	});
 });
 
 describe('cleanupPlainText', () => {

--- a/app/src/helpers/helpers.test.ts
+++ b/app/src/helpers/helpers.test.ts
@@ -261,18 +261,16 @@ describe('removeUserAgentSpecifics', () => {
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.128 Safari/537.36',
     );
   });
-	
-	test('should not have multiple spaces in a row', () => {
+
+  test('should not have multiple spaces in a row', () => {
     expect(
       removeUserAgentSpecifics(
         userAgentFallback,
         'app-nativefier-804458',
         '1.0.0',
       ),
-		).toEqual(expect.not.stringMatching(
-			/\s{2,}/
-    ));
-	});
+    ).toEqual(expect.not.stringMatching(/\s{2,}/));
+  });
 });
 
 describe('cleanupPlainText', () => {

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -183,7 +183,7 @@ export function removeUserAgentSpecifics(
   // We just need to strip out the appName/1.0.0 and Electron/electronVersion
   return userAgentFallback
     .replace(`Electron/${process.versions.electron} `, '')
-    .replace(`${appName}/${appVersion} `, ' ');
+    .replace(`${appName}/${appVersion} `, '');
 }
 
 /** Removes extra spaces from a text */


### PR DESCRIPTION
Fixes https://github.com/nativefier/nativefier/issues/1357 by not adding a new space when removing the app name from the User-Agent.