### PR TITLE
--counter: accept colon character (useful for time-tracking apps with hour:min)

### DIFF
--- a/app/src/helpers/helpers.test.ts
+++ b/app/src/helpers/helpers.test.ts
@@ -233,6 +233,7 @@ test.each(testNonLoginPages)(
 
 const smallCounterTitle = 'Inbox (11) - nobody@example.com - Gmail';
 const largeCounterTitle = 'Inbox (8,756) - nobody@example.com - Gmail';
+const hourCounterTitle = 'Today (1:23) - nobody@example.com - TimeTracker';
 const noCounterTitle = 'Inbox - nobody@example.com - Gmail';
 
 test('getCounterValue should return undefined for titles without counter numbers', () => {
@@ -245,6 +246,10 @@ test('getCounterValue should return a string for small counter numbers in the ti
 
 test('getCounterValue should return a string for large counter numbers in the title', () => {
   expect(getCounterValue(largeCounterTitle)).toEqual('8,756');
+});
+
+test('getCounterValue should return a string for hour counter numbers in the title', () => {
+  expect(getCounterValue(hourCounterTitle)).toEqual('1:23');
 });
 
 describe('removeUserAgentSpecifics', () => {

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -56,7 +56,7 @@ export function getAppIcon(): string | undefined {
 }
 
 export function getCounterValue(title: string): string | undefined {
-  const itemCountRegex = /[([{]([\d.,]*)\+?[}\])]/;
+  const itemCountRegex = /[([{]([\d.,:]*)\+?[}\])]/;
   const match = itemCountRegex.exec(title);
   return match ? match[1] : undefined;
 }


### PR DESCRIPTION
Modify regexp to track hour counters such as `(1:23)`.