### PR TITLE
Include VMWare Workspace ONE SSO Internal URLs

### DIFF
--- a/API.md
+++ b/API.md
@@ -795,6 +795,8 @@ Current known internal login pages:
 - `login.live.com` , `login.microsoftonline.com`
 - `okta.com`
 - `twitter.com/oauth/authenticate`
+- `workspaceair.com`
+- `securid.com`
 
 Note: While .com is specified, for most of these we try to match even on non-US
 based domains such as `.co.uk` as well

--- a/app/src/helpers/helpers.test.ts
+++ b/app/src/helpers/helpers.test.ts
@@ -200,6 +200,8 @@ const testLoginPages = [
   'https://appleid.apple.com/auth/authorize',
   'https://id.atlassian.com',
   'https://auth.atlassian.com',
+  'https://vmware.workspaceair.com',
+  'https://vmware.auth.securid.com',
 ];
 
 test.each(testLoginPages)(

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -106,6 +106,8 @@ function isInternalLoginPage(url: string): boolean {
     'twitter\\.[a-zA-Z\\.]*/oauth/authenticate', // Twitter
     'appleid\\.apple\\.com/auth/authorize', // Apple
     '(?:id|auth)\\.atlassian\\.[a-zA-Z]+', // Atlassian
+    '.*\\.workspaceair\\.com', // VMWare Workspace One SSO
+    '.*\\.securid\\.com', // SecurID for VMWare Workspace One SSO
   ];
   // Making changes? Remember to update the tests in helpers.test.ts and in API.md
   const regex = RegExp(internalLoginPagesArray.join('|'));


### PR DESCRIPTION
Update internal URLs to include VMware's Workspace ONE and SecurID.

Fixes #1390