### PR TITLE
Handle 'open-url' event: support "deep-linking" e.g. for mailto links (fix #1412)

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -228,6 +228,15 @@ app.on('will-finish-launching', () => {
   log.debug('app.will-finish-launching');
 });
 
+app.on('open-url', (event, url) => {
+  log.debug('app.open-url', { event, url });
+
+  event.preventDefault();
+  if (mainWindow) {
+    mainWindow.webContents.send('open-url', url);
+  }
+});
+
 if (appArgs.widevine) {
   // @ts-expect-error This event only appears on the widevine version of electron, which we'd see at runtime
   app.on('widevine-ready', (version: string, lastVersion: string) => {


### PR DESCRIPTION
Closes #1412 