### PR TITLE
Major-bump default Electron from 18 to 19

### DIFF
--- a/app/npm-shrinkwrap.json
+++ b/app/npm-shrinkwrap.json
@@ -17,7 +17,7 @@
         "source-map-support": "^0.5.19"
       },
       "devDependencies": {
-        "electron": "^18.3.5"
+        "electron": "^19.0.9"
       }
     },
     "node_modules/@electron/get": {
@@ -303,13 +303,13 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.5.tgz",
-      "integrity": "sha512-/GJ39X3ijpyZiOtYQ1ha5Ly0hWiIzF19CGEapM9euaM2AZrmt79x+MckQDXqJxOaVA9YHXju5Ho6b9pB9a/2pQ==",
+      "version": "19.0.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.9.tgz",
+      "integrity": "sha512-ooEwrv8Y7NSzdhKcl6kPCYecnzcg5nFWuS5ryG+VFH3MMBR8zXh9nW2wLsZrBz6OGUxXrcc5BKBC7dA8C6RhGQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@electron/get": "^1.13.0",
+        "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       },
@@ -1491,12 +1491,12 @@
       "dev": true
     },
     "electron": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.5.tgz",
-      "integrity": "sha512-/GJ39X3ijpyZiOtYQ1ha5Ly0hWiIzF19CGEapM9euaM2AZrmt79x+MckQDXqJxOaVA9YHXju5Ho6b9pB9a/2pQ==",
+      "version": "19.0.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.9.tgz",
+      "integrity": "sha512-ooEwrv8Y7NSzdhKcl6kPCYecnzcg5nFWuS5ryG+VFH3MMBR8zXh9nW2wLsZrBz6OGUxXrcc5BKBC7dA8C6RhGQ==",
       "dev": true,
       "requires": {
-        "@electron/get": "^1.13.0",
+        "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -20,6 +20,6 @@
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {
-    "electron": "^18.3.5"
+    "electron": "^19.0.9"
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -38,7 +38,7 @@
         "@types/yargs": "^17.0.10",
         "@typescript-eslint/eslint-plugin": "^5.3.0",
         "@typescript-eslint/parser": "^5.3.0",
-        "electron": "^18.3.5",
+        "electron": "^19.0.9",
         "eslint": "^8.1.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
@@ -2905,13 +2905,13 @@
       "integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA=="
     },
     "node_modules/electron": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.5.tgz",
-      "integrity": "sha512-/GJ39X3ijpyZiOtYQ1ha5Ly0hWiIzF19CGEapM9euaM2AZrmt79x+MckQDXqJxOaVA9YHXju5Ho6b9pB9a/2pQ==",
+      "version": "19.0.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.9.tgz",
+      "integrity": "sha512-ooEwrv8Y7NSzdhKcl6kPCYecnzcg5nFWuS5ryG+VFH3MMBR8zXh9nW2wLsZrBz6OGUxXrcc5BKBC7dA8C6RhGQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@electron/get": "^1.13.0",
+        "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       },
@@ -9695,12 +9695,12 @@
       "integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA=="
     },
     "electron": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.3.5.tgz",
-      "integrity": "sha512-/GJ39X3ijpyZiOtYQ1ha5Ly0hWiIzF19CGEapM9euaM2AZrmt79x+MckQDXqJxOaVA9YHXju5Ho6b9pB9a/2pQ==",
+      "version": "19.0.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.9.tgz",
+      "integrity": "sha512-ooEwrv8Y7NSzdhKcl6kPCYecnzcg5nFWuS5ryG+VFH3MMBR8zXh9nW2wLsZrBz6OGUxXrcc5BKBC7dA8C6RhGQ==",
       "dev": true,
       "requires": {
-        "@electron/get": "^1.13.0",
+        "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@types/yargs": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "@typescript-eslint/parser": "^5.3.0",
-    "electron": "^18.3.5",
+    "electron": "^19.0.9",
     "eslint": "^8.1.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,22 +2,23 @@ import * as path from 'path';
 
 export const DEFAULT_APP_NAME = 'APP';
 
-// Update both DEFAULT_ELECTRON_VERSION and DEFAULT_CHROME_VERSION together,
-// and update package.json / devDeps / electron to value of DEFAULT_ELECTRON_VERSION
-// and update app / package.json / devDeps / electron to value of DEFAULT_ELECTRON_VERSION
-export const DEFAULT_ELECTRON_VERSION = '18.3.5';
+// Upgrade both DEFAULT_ELECTRON_VERSION and DEFAULT_CHROME_VERSION together, and
+//   - upgrade app / package.json / "devDependencies" / "electron"
+//   - upgrade       package.json / "devDependencies" / "electron"
+// Doing a *major* upgrade? Read https://github.com/nativefier/nativefier/blob/master/HACKING.md#deps-major-upgrading-electron
+export const DEFAULT_ELECTRON_VERSION = '19.0.9';
 // https://atom.io/download/atom-shell/index.json
-export const DEFAULT_CHROME_VERSION = '100.0.4896.160';
+export const DEFAULT_CHROME_VERSION = '102.0.5005.167';
 
 // Update each of these periodically
 // https://product-details.mozilla.org/1.0/firefox_versions.json
-export const DEFAULT_FIREFOX_VERSION = '101.0.1';
+export const DEFAULT_FIREFOX_VERSION = '102.0.1';
 
 // https://en.wikipedia.org/wiki/Safari_version_history
 export const DEFAULT_SAFARI_VERSION = {
   majorVersion: 15,
-  version: '15.4',
-  webkitVersion: '605.1.15',
+  version: '15.5',
+  webkitVersion: '613.2.7',
 };
 
 export const ELECTRON_MAJOR_VERSION = parseInt(


### PR DESCRIPTION
https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-190
https://github.com/electron/electron/releases/tag/v19.0.0
https://github.com/electron/electron/releases/tag/v19.0.1
https://github.com/electron/electron/releases/tag/v19.0.2
https://github.com/electron/electron/releases/tag/v19.0.3
https://github.com/electron/electron/releases/tag/v19.0.4
https://github.com/electron/electron/releases/tag/v19.0.5
https://github.com/electron/electron/releases/tag/v19.0.6
https://github.com/electron/electron/releases/tag/v19.0.7
https://github.com/electron/electron/releases/tag/v19.0.8
https://github.com/electron/electron/releases/tag/v19.0.9