### PR TITLE
Remove ia32 as it's no longer supported in Electron 19 (fix #1439)

### DIFF
--- a/API.md
+++ b/API.md
@@ -158,7 +158,7 @@ The processor architecture to target when building.
     ```
     (See https://nodejs.org/api/os.html#os_os_arch)
   - Please note: On M1 Macs, unless an arm64 version of brew is used to install nodejs, the version installed will be an `x64` version run through Rosetta, and will result in an `x64` app being generated. If this is not desired, either specify `-a arm64` to build for M1, or re-install node with an arm64 version of brew. See https://github.com/nativefier/nativefier/issues/1089
-- Can be overridden by specifying one of: `ia32`, `x64`, `armv7l`, `arm64`, or `universal`
+- Can be overridden by specifying one of: `x64`, `armv7l`, `arm64`, or `universal`
 - When specifying `universal` you must be building for the `darwin`, `mas`, `mac`, or `osx` platforms. This will generate a universal (M1 and x86) app.
 
 Note: careful to not conflate _platform_ with _architecture_. If you want for example a Linux or Mac build, it's `--platform` you are looking for. See its documentation for details.

--- a/src/infer/inferOs.ts
+++ b/src/infer/inferOs.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as log from 'loglevel';
 
 // Ideally we'd get this list directly from electron-packager, but it's not
-// possible to convert a literal type in an array of strings in current TypeScript
+// possible to convert a literal type to an array of strings in current TypeScript
 export const supportedArchs = ['x64', 'armv7l', 'arm64', 'universal'];
 export const supportedPlatforms = [
   'darwin',

--- a/src/infer/inferOs.ts
+++ b/src/infer/inferOs.ts
@@ -3,11 +3,8 @@ import * as os from 'os';
 import * as log from 'loglevel';
 
 // Ideally we'd get this list directly from electron-packager, but it's not
-// accessible in the package without importing its private js files, which felt
-// dirty. So if those change, we'll update these as well.
-// https://electron.github.io/electron-packager/master/interfaces/electronpackager.options.html#platform
-// https://electron.github.io/electron-packager/master/interfaces/electronpackager.options.html#arch
-export const supportedArchs = ['ia32', 'x64', 'armv7l', 'arm64', 'universal'];
+// possible to convert a literal type in an array of strings in current TypeScript
+export const supportedArchs = ['x64', 'armv7l', 'arm64', 'universal'];
 export const supportedPlatforms = [
   'darwin',
   'linux',

--- a/src/integration-test.ts
+++ b/src/integration-test.ts
@@ -164,11 +164,9 @@ describe('Nativefier upgrade', () => {
     // Exhaustive integration testing here would be neat, but takes too long.
     // -> For now, only testing a subset of platforms/archs
     // { platform: 'win32', arch: 'x64' },
-    // { platform: 'win32', arch: 'ia32' },
     // { platform: 'darwin', arch: 'arm64' },
     // { platform: 'linux', arch: 'x64' },
     // { platform: 'linux', arch: 'armv7l' },
-    // { platform: 'linux', arch: 'ia32' },
   ])(
     'can upgrade a Nativefier app for platform/arch: %s',
     async (baseAppOptions) => {


### PR DESCRIPTION
Fixes #1439 