### PR TITLE
Add ability to use "compact title bar" for Windows builds

### DIFF
--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -59,6 +59,7 @@ export async function createMainWindow(
 
   const mainWindow = new BrowserWindow({
     frame: !options.hideWindowFrame,
+    thickFrame: options.thickFrame,
     width: mainWindowState.width,
     height: mainWindowState.height,
     minWidth: options.minWidth,

--- a/shared/src/options/model.ts
+++ b/shared/src/options/model.ts
@@ -45,6 +45,7 @@ export interface AppOptions {
     fullScreen: boolean;
     globalShortcuts?: GlobalShortcut[];
     hideWindowFrame: boolean;
+    thickFrame?: boolean;
     ignoreCertificate: boolean;
     ignoreGpuBlacklist: boolean;
     inject?: string[];
@@ -163,6 +164,7 @@ export type RawOptions = {
   globalShortcuts?: string | GlobalShortcut[];
   height?: number;
   hideWindowFrame?: boolean;
+  thickFrame?: boolean;
   icon?: string;
   ignoreCertificate?: boolean;
   ignoreGpuBlacklist?: boolean;

--- a/src/build/prepareElectronApp.ts
+++ b/src/build/prepareElectronApp.ts
@@ -56,6 +56,7 @@ function pickElectronAppArgs(options: AppOptions): OutputOptions {
     height: options.nativefier.height,
     helperBundleId: options.packager.helperBundleId,
     hideWindowFrame: options.nativefier.hideWindowFrame,
+    thickFrame: options.nativefier.thickFrame,
     ignoreCertificate: options.nativefier.ignoreCertificate,
     ignoreGpuBlacklist: options.nativefier.ignoreGpuBlacklist,
     insecure: options.nativefier.insecure,

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -213,6 +213,7 @@ describe('initArgs + parseArgs', () => {
     { arg: 'flash', shortArg: '' },
     { arg: 'full-screen', shortArg: '' },
     { arg: 'hide-window-frame', shortArg: '' },
+    { arg: 'compact-title-bar', shortArg: '' },
     { arg: 'honest', shortArg: '' },
     { arg: 'ignore-certificate', shortArg: '' },
     { arg: 'ignore-gpu-blacklist', shortArg: '' },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -203,6 +203,11 @@ export function initArgs(argv: string[]): yargs.Argv<RawOptions> {
       description: 'disable window frame and controls',
       type: 'boolean',
     })
+    .option('compact-title-bar', {
+      default: false,
+      description: '[Windows only] use a more compact title bar',
+      type: 'boolean',
+    })
     .option('m', {
       alias: 'show-menu-bar',
       default: false,
@@ -279,6 +284,7 @@ export function initArgs(argv: string[]): yargs.Argv<RawOptions> {
         'full-screen',
         'height',
         'hide-window-frame',
+        'compact-title-bar',
         'm',
         'max-width',
         'max-height',
@@ -593,8 +599,11 @@ export function parseArgs(args: yargs.Argv<RawOptions>): RawOptions {
       'ERROR: Nativefier must be called with either a targetUrl or the --upgrade option.\n',
     );
   }
-
   parsed.noOverwrite = parsed['no-overwrite'] = !parsed.overwrite;
+
+  if (parsed.compactTitleBar) {
+    parsed.thickFrame = false;
+  }
 
   // Since coerce in yargs seems to have broken since
   // https://github.com/yargs/yargs/pull/1978

--- a/src/options/optionsMain.test.ts
+++ b/src/options/optionsMain.test.ts
@@ -30,6 +30,7 @@ const mockedAsyncConfig: AppOptions = {
     fullScreen: false,
     globalShortcuts: undefined,
     height: undefined,
+    thickFrame: true,
     hideWindowFrame: false,
     ignoreCertificate: false,
     ignoreGpuBlacklist: false,

--- a/src/options/optionsMain.ts
+++ b/src/options/optionsMain.ts
@@ -92,6 +92,7 @@ export async function getOptions(rawOptions: RawOptions): Promise<AppOptions> {
       fullScreen: rawOptions.fullScreen ?? false,
       globalShortcuts: undefined,
       hideWindowFrame: rawOptions.hideWindowFrame ?? false,
+      thickFrame: rawOptions.thickFrame ?? true,
       ignoreCertificate: rawOptions.ignoreCertificate ?? false,
       ignoreGpuBlacklist: rawOptions.ignoreGpuBlacklist ?? false,
       inject: rawOptions.inject ?? [],


### PR DESCRIPTION
Electron provides the option `thickFrame` to control whether the app is
built with the WS_THICKFRAME option. This is enabled by default so this
commit adds the new flag `--compact-title-bar` to nativefier which will
disable the `thickFrame` option.

The image below highlights the difference made by disabling `thickFrame`.

![image](https://user-images.githubusercontent.com/17223437/185590024-5bbbce7e-1e53-4321-beac-fd88655b39c4.png)

I haven't worked much with Javascript in a while and am not really familiar with Typescript so if I missed anything just let me know and I'll fix it up!