### PR TITLE
Add getDisplayMedia and PipeWire support

### DIFF
--- a/.github/manual-test
+++ b/.github/manual-test
@@ -101,3 +101,23 @@ printf '\n***** SMOKE TEST 3: Test checklist *****
 
 launch_app "$tmp_dir" "$name"
 request_feedback "$tmp_dir"
+
+# ------------------------------------------------------------------------------
+
+printf '\n***** SMOKE TEST 4: Setting up test and building app... *****\n'
+tmp_dir=$(mktemp -d -t nativefier-manual-test-start-in-tray-XXXXX)
+name='nativefier-smoke-test-4'
+node ./lib/cli.js 'https://meet.jit.si/nativefier-test' \
+  --name "$name" \
+  "$tmp_dir"
+
+printf '\n***** SMOKE TEST 4: Test checklist *****
+- Join the Jitsi meeting and try to share your screen
+  (third button from the left in the bottom bar)
+- An overlay should appear where you can select a screen/window to share
+- After selecting a screen, a thumbnail of the shared screen should appear on
+  the top right
+- Console: no Electron runtime deprecation warnings/error logged'
+
+launch_app "$tmp_dir" "$name"
+request_feedback "$tmp_dir"

--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -232,7 +232,7 @@ function setupSessionPermissionHandler(window: BrowserWindow): void {
     },
   );
   window.webContents.session.setPermissionRequestHandler(
-    async (_webContents, _permission, callback, _details) => {
+    (_webContents, _permission, callback, _details) => {
       callback(true);
     },
   );

--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -149,6 +149,7 @@ export async function createMainWindow(
   });
 
   setupSessionInteraction(options, mainWindow);
+  setupSessionPermissionHandler(mainWindow);
 
   if (options.clearCache) {
     await clearCache(mainWindow);
@@ -221,6 +222,15 @@ function setupCounter(
     } else {
       setDockBadge('');
     }
+  });
+}
+
+function setupSessionPermissionHandler(window: BrowserWindow): void {
+  window.webContents.session.setPermissionCheckHandler((_webContents, _permission, _details) => {
+    return true;
+  });
+  window.webContents.session.setPermissionRequestHandler(async (_webContents, _permission, callback, _details) => {
+    callback(true);
   });
 }
 

--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -226,13 +226,11 @@ function setupCounter(
 }
 
 function setupSessionPermissionHandler(window: BrowserWindow): void {
-  window.webContents.session.setPermissionCheckHandler(
-    (_webContents, _permission, _details) => {
-      return true;
-    },
-  );
+  window.webContents.session.setPermissionCheckHandler(() => {
+    return true;
+  });
   window.webContents.session.setPermissionRequestHandler(
-    (_webContents, _permission, callback, _details) => {
+    (_webContents, _permission, callback) => {
       callback(true);
     },
   );

--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -226,12 +226,16 @@ function setupCounter(
 }
 
 function setupSessionPermissionHandler(window: BrowserWindow): void {
-  window.webContents.session.setPermissionCheckHandler((_webContents, _permission, _details) => {
-    return true;
-  });
-  window.webContents.session.setPermissionRequestHandler(async (_webContents, _permission, callback, _details) => {
-    callback(true);
-  });
+  window.webContents.session.setPermissionCheckHandler(
+    (_webContents, _permission, _details) => {
+      return true;
+    },
+  );
+  window.webContents.session.setPermissionRequestHandler(
+    async (_webContents, _permission, callback, _details) => {
+      callback(true);
+    },
+  );
 }
 
 function setupNotificationBadge(

--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { ipcMain, BrowserWindow, Event } from 'electron';
+import { ipcMain, desktopCapturer, BrowserWindow, Event } from 'electron';
 import windowStateKeeper from 'electron-window-state';
 
 import { initContextMenu } from './contextMenu';
@@ -234,6 +234,11 @@ function setupSessionPermissionHandler(window: BrowserWindow): void {
       callback(true);
     },
   );
+  ipcMain.handle('desktop-capturer-get-sources', () => {
+    return desktopCapturer.getSources({
+      types: ['screen', 'window'],
+    });
+  });
 }
 
 function setupNotificationBadge(

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -263,7 +263,7 @@ export function openExternal(
 }
 
 export function isWayland(): boolean {
-  return isLinux() && process.env.XDG_SESSION_TYPE === 'wayland'; 
+  return isLinux() && (Boolean(process.env.WAYLAND_DISPLAY) || process.env.XDG_SESSION_TYPE === 'wayland'); 
 }
 
 export function removeUserAgentSpecifics(

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -263,7 +263,11 @@ export function openExternal(
 }
 
 export function isWayland(): boolean {
-  return isLinux() && (Boolean(process.env.WAYLAND_DISPLAY) || process.env.XDG_SESSION_TYPE === 'wayland'); 
+  return (
+    isLinux() &&
+    (Boolean(process.env.WAYLAND_DISPLAY) ||
+      process.env.XDG_SESSION_TYPE === 'wayland')
+  );
 }
 
 export function removeUserAgentSpecifics(

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -262,6 +262,8 @@ export function openExternal(
   return shell.openExternal(url, options);
 }
 
+// Copy-pastaed as unable to get imports to work in preload.
+// If modifying, update also app/src/preload.ts
 export function isWayland(): boolean {
   return (
     isLinux() &&

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { spawnSync as nodeSpawnSync } from 'node:child_process';
 
 import { BrowserWindow, OpenExternalOptions, shell } from 'electron';
 
@@ -264,12 +263,7 @@ export function openExternal(
 }
 
 export function isWayland(): boolean {
-  return isLinux() && spawnSync('echo', ['$XDG_SESSION_TYPE']).includes('wayland');
-}
-
-export function spawnSync(cmd: string, args: string[]): string {
-  const result = nodeSpawnSync(cmd, args, { encoding: 'utf-8' });
-  return result.stdout;
+  return isLinux() && process.env.XDG_SESSION_TYPE === 'wayland'; 
 }
 
 export function removeUserAgentSpecifics(

--- a/app/src/helpers/helpers.ts
+++ b/app/src/helpers/helpers.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { spawnSync as nodeSpawnSync } from 'node:child_process';
 
 import { BrowserWindow, OpenExternalOptions, shell } from 'electron';
 
@@ -260,6 +261,15 @@ export function openExternal(
   }
 
   return shell.openExternal(url, options);
+}
+
+export function isWayland(): boolean {
+  return isLinux() && spawnSync('echo', ['$XDG_SESSION_TYPE']).includes('wayland');
+}
+
+export function spawnSync(cmd: string, args: string[]): string {
+  const result = nodeSpawnSync(cmd, args, { encoding: 'utf-8' });
+  return result.stdout;
 }
 
 export function removeUserAgentSpecifics(

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -20,7 +20,12 @@ import {
   APP_ARGS_FILE_PATH,
 } from './components/mainWindow';
 import { createTrayIcon } from './components/trayIcon';
-import { isOSX, isWayland, isWindows, removeUserAgentSpecifics } from './helpers/helpers';
+import {
+  isOSX,
+  isWayland,
+  isWindows,
+  removeUserAgentSpecifics,
+} from './helpers/helpers';
 import { inferFlashPath } from './helpers/inferFlash';
 import * as log from './helpers/loggingHelper';
 import {

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -20,7 +20,7 @@ import {
   APP_ARGS_FILE_PATH,
 } from './components/mainWindow';
 import { createTrayIcon } from './components/trayIcon';
-import { isOSX, isWindows, removeUserAgentSpecifics } from './helpers/helpers';
+import { isOSX, isWayland, isWindows, removeUserAgentSpecifics } from './helpers/helpers';
 import { inferFlashPath } from './helpers/inferFlash';
 import * as log from './helpers/loggingHelper';
 import {
@@ -178,6 +178,10 @@ if (appArgs.basicAuthPassword) {
     'basic-auth-password',
     appArgs.basicAuthPassword,
   );
+}
+
+if (isWayland()) {
+  app.commandLine.appendSwitch('enable-features', 'WebRTCPipeWireCapturer');
 }
 
 if (appArgs.lang) {

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -86,13 +86,19 @@ function setupScreenSharePickerStyles(id: string): void {
   screenShareStyles.id = id;
   screenShareStyles.innerHTML = `
   .desktop-capturer-selection {
+    --overlay-color: hsla(0, 0%, 11.8%, 0.75);
+    --highlight-color: highlight;
+    --text-content-color: #fff;
+    --selection-button-color: hsl(180, 1.3%, 14.7%);
+  }
+  .desktop-capturer-selection {
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
     height: 100vh;
-    background: rgba(30,30,30,.75);
-    color: #fff;
+    background: var(--overlay-color);
+    color: var(--text-content-color);
     z-index: 10000000;
     display: flex;
     align-items: center;
@@ -103,7 +109,7 @@ function setupScreenSharePickerStyles(id: string): void {
     -webkit-appearance: none;
     appearance: none;
     padding: 1rem;
-    color: #fff;
+    color: inherit;
     position: absolute;
     left: 1rem;
     top: 1rem;
@@ -137,13 +143,13 @@ function setupScreenSharePickerStyles(id: string): void {
     border: 0;
     border-radius: 3px;
     padding: 4px;
-    background: #252626;
+    background: var(--selection-button-color);
     text-align: left;
     transition: background-color .15s, box-shadow .15s;
   }
   .desktop-capturer-selection__btn:hover,
   .desktop-capturer-selection__btn:focus {
-    background: rgba(98,100,167,.8);
+    background: var(--highlight-color);
   }
   .desktop-capturer-selection__thumbnail {
     width: 100%;
@@ -155,6 +161,13 @@ function setupScreenSharePickerStyles(id: string): void {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+  }
+  @media (prefers-color-scheme: light) {
+    .desktop-capturer-selection {
+      --overlay-color: hsla(0, 0%, 90.2%, 0.75);
+      --text-content-color: hsl(0, 0%, 12.9%);
+      --selection-button-color: hsl(180, 1.3%, 85.3%);
+    }
   }`;
   document.head.appendChild(screenShareStyles);
 }

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -225,6 +225,7 @@ function setupScreenSharePicker(
     .getElementById(`${baseElementsId}-close`)
     ?.addEventListener('click', () => {
       clearElements();
+      reject('Screen share was cancelled by the user.');
     });
 
   document

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -164,12 +164,12 @@ function setupScreenSharePickerElement(
   selectionElem.classList.add('desktop-capturer-selection');
   selectionElem.id = id;
   selectionElem.innerHTML = `
+    <button class="desktop-capturer-selection__close" id="${id}-close" aria-label="Close screen share picker" type="button">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32">
+      <path fill="currentColor" d="m12 10.586 4.95-4.95 1.414 1.414-4.95 4.95 4.95 4.95-1.414 1.414-4.95-4.95-4.95 4.95-1.414-1.414 4.95-4.95-4.95-4.95L7.05 5.636z"/>   
+      </svg>
+    </button>
     <div class="desktop-capturer-selection__scroller">
-      <button class="desktop-capturer-selection__close" id="${id}-close" aria-label="Close screen share picker" type="button">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32">
-        <path fill="currentColor" d="m12 10.586 4.95-4.95 1.414 1.414-4.95 4.95 4.95 4.95-1.414 1.414-4.95-4.95-4.95 4.95-1.414-1.414 4.95-4.95-4.95-4.95L7.05 5.636z"/>   
-        </svg>
-      </button>
       <ul class="desktop-capturer-selection__list">
         ${sources.map(({ id, name, thumbnail }) => `
           <li class="desktop-capturer-selection__item">

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -331,6 +331,8 @@ ipcRenderer.on('debug', (event, message: string) => {
   log.debug('ipcRenderer.debug', { event, message });
 });
 
+// Copy-pastaed as unable to get imports to work in preload.
+// If modifying, update also app/src/helpers/helpers.ts
 function isWayland(): boolean {
   return (
     isLinux() &&


### PR DESCRIPTION
I'm picking up @RickStanley's abandoned PR #1321 again to add screensharing support (fixes #927), with the following additional changes:

- In newer Electron versions, `desktopCapturer.getSources` must be called from the main process, so I solved this with an IPC call.
- Importing from `./helpers/helpers` in 'preload.ts' does not work, as was mentioned by @DimICE in https://github.com/nativefier/nativefier/pull/1321#issuecomment-1001518035. I'm not very familiar with TypeScript or Electron, so not sure why that is and how it could be solved - for now I just copied the referenced `isWayland` function to `preload.ts`.
- Add a screensharing test to the manual test script, as requested by @ronjouch in https://github.com/nativefier/nativefier/pull/1321#issuecomment-1006725818

As far as I understood from the discussion in #1321, the last point was basically the only thing that was missing to get this merged, correct?